### PR TITLE
Replace binary image assets with symbol-based visuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Xcode build artifacts
+DerivedData/
+build/
+
+# Workspace user data
+xcuserdata/
+*.xcuserstate
+
+# Swift Package Manager
+.swiftpm/
+.build/
+
+# macOS metadata
+.DS_Store
+
+# Archives
+*.zip

--- a/JourneyTH.xcodeproj/project.pbxproj
+++ b/JourneyTH.xcodeproj/project.pbxproj
@@ -1,0 +1,503 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+	0B401BE29AC547BE97B2BBC9B6627BB6 /* transport.json in Resources */ = {isa = PBXBuildFile; fileRef = DF962B16DC574B18864520BB6C8F7B71 /* transport.json */; };
+	0F94DB5B0FFD414B94AD397F66E56566 /* SharedComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BE5809471D4ACAA1CA31ABC1A828CF /* SharedComponents.swift */; };
+	1929634F6BC04705965471981ED5791D /* PaymentsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E07DDF5C5684C05B2C6180FD987004E /* PaymentsFeature.swift */; };
+	1B6300A431CB49C9B9C9AE33DFCDB2AA /* esim_plans.json in Resources */ = {isa = PBXBuildFile; fileRef = 91072CA6FE4546D1B11A026EA69CFD82 /* esim_plans.json */; };
+	2440393F08554AB9A76B5F8E2510A5BA /* PoiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EF10CCC0CE4398B9EB7064F895E64A /* PoiService.swift */; };
+	45D007163FE0497FAB2C8BA754485F1C /* DiscoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C726873733654A5AAAF6C20DC82E409C /* DiscoverFeature.swift */; };
+	4B108C3A7DAF479093E851E79F1FA206 /* JourneyTHApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FAABA271344FB88FE4C5787F826043 /* JourneyTHApp.swift */; };
+	5801E565694C43B4AEBD4E24883BDE5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9BDE6A65E50B42DAA7F0FCACE4E92175 /* Assets.xcassets */; };
+	6EE7497C8BA94366BF71BADBAAB3B6D5 /* EsimPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = F458FA79BA7C4F54BE5D37BA6F10D472 /* EsimPlan.swift */; };
+	7488EBB0C5D04819A202E98D74273823 /* TransportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD204A9303E4AEA898B8870E6A3EA6A /* TransportService.swift */; };
+	7A7795B785544A33BD9E6A684293CD1C /* TransportRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A56803A65249C3A5630D2CC1411923 /* TransportRoute.swift */; };
+	8F7AD27BF2F4478791EAD2E08A94FB06 /* ItineraryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56820073EF24CBD8E17952FC55E21CF /* ItineraryFeature.swift */; };
+	9B334F16F8394AE1A85A13EB87239E3D /* EsimFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E606100D0DF34F5294D288409D91ED2A /* EsimFeature.swift */; };
+	9DF485B541FB495BA3AB03F3FA70DAFE /* pois.json in Resources */ = {isa = PBXBuildFile; fileRef = 91C05ECBF1644A69BB0977C6EC8BB656 /* pois.json */; };
+	AA8829520D574593B2BE06F9A2D5252F /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A986428DD23477AAC6355BDD9A2D5C9 /* Persistence.swift */; };
+	B3E3EF69B8714C8EB3E12813A98B3C34 /* OrderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D77BEDAEFF74199B55147D585E814C2 /* OrderModel.swift */; };
+	BA964D783A6C4FC49CB22A946A016EB8 /* AccountFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8927F09F3C46BFA3E1AB54A2573C45 /* AccountFeature.swift */; };
+	CA08AEE838414AAD8190629D7522D4D4 /* PlanLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC46CE28CE744A56B56D012F8855A4DA /* PlanLoader.swift */; };
+	D079E00F5BFF442E8B3E058370F57DBD /* OrderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16245B883427418D8E6EB5E715C2608D /* OrderService.swift */; };
+	E12A73A08ECD47DF8681D9109908DC95 /* LocalDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E25C83484E4C5D85F2759A83C8B002 /* LocalDataLoader.swift */; };
+	EF419844F2084FC0904F53003C96382B /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C0BD92CD2642EFB42B64D0B096EDEE /* AppSettings.swift */; };
+	F870F5C828DA4AE3A8AB3B43507FA391 /* TransportFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76BAEE7AA8CD42888B6B8297F411B8A2 /* TransportFeature.swift */; };
+	FF192049B2AC4E7BB21949AF6945662E /* JourneyTH.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 6ADEDD1F99744762AAA2BC49BD418770 /* JourneyTH.xcdatamodeld */; };
+	A94D8F43BA194F0D94B5602F00D5F01E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 814928D0D8DD4EE3B92B8702FFA15231 /* Localizable.strings */; };
+	A623F952FAFE4F3CB6B23909FC329D80 /* TransportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9639B5FA9442EF8C93471C274351F2 /* TransportViewModelTests.swift */; };
+	6408A3AF5B424F7B8302A613E58108AF /* PoiViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF06062C05041329C88A5C549D9C188 /* PoiViewModelTests.swift */; };
+	3ABCFA3A7D0D4E4EAE2866772E2F8201 /* ItineraryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66E467385C24E37AC1397AF80F041C9 /* ItineraryRepositoryTests.swift */; };
+	05833FE86B234D20AAE4651C70D84BE2 /* OrderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A4D820998E4546898C8695748D6604 /* OrderServiceTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+	0277F47312AB481FBD115BB4A9F61D96 /* PBXContainerItemProxy */ = {isa = PBXContainerItemProxy; containerPortal = 37088684A8C14E49AF159A3CB05ADBDB /* Project object */; proxyType = 1; remoteGlobalIDString = 39B43CB0CC254B7EB0DC56A68B1B3DA8; remoteInfo = JourneyTH; };
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+	B1FAABA271344FB88FE4C5787F826043 /* JourneyTHApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyTHApp.swift; sourceTree = <group>; };
+	05C0BD92CD2642EFB42B64D0B096EDEE /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = <group>; };
+	C9BE5809471D4ACAA1CA31ABC1A828CF /* SharedComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedComponents.swift; sourceTree = <group>; };
+	76BAEE7AA8CD42888B6B8297F411B8A2 /* TransportFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFeature.swift; sourceTree = <group>; };
+	C726873733654A5AAAF6C20DC82E409C /* DiscoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverFeature.swift; sourceTree = <group>; };
+	A56820073EF24CBD8E17952FC55E21CF /* ItineraryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryFeature.swift; sourceTree = <group>; };
+	E606100D0DF34F5294D288409D91ED2A /* EsimFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EsimFeature.swift; sourceTree = <group>; };
+	5E07DDF5C5684C05B2C6180FD987004E /* PaymentsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsFeature.swift; sourceTree = <group>; };
+	BD8927F09F3C46BFA3E1AB54A2573C45 /* AccountFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountFeature.swift; sourceTree = <group>; };
+	F5A56803A65249C3A5630D2CC1411923 /* TransportRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportRoute.swift; sourceTree = <group>; };
+	491BAA9C25A8486C8B4A912173BDFF9C /* Poi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Poi.swift; sourceTree = <group>; };
+	F458FA79BA7C4F54BE5D37BA6F10D472 /* EsimPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EsimPlan.swift; sourceTree = <group>; };
+	5D77BEDAEFF74199B55147D585E814C2 /* OrderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderModel.swift; sourceTree = <group>; };
+	F5E25C83484E4C5D85F2759A83C8B002 /* LocalDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataLoader.swift; sourceTree = <group>; };
+	6CD204A9303E4AEA898B8870E6A3EA6A /* TransportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportService.swift; sourceTree = <group>; };
+	36EF10CCC0CE4398B9EB7064F895E64A /* PoiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoiService.swift; sourceTree = <group>; };
+	16245B883427418D8E6EB5E715C2608D /* OrderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderService.swift; sourceTree = <group>; };
+	9A986428DD23477AAC6355BDD9A2D5C9 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = <group>; };
+	FC46CE28CE744A56B56D012F8855A4DA /* PlanLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanLoader.swift; sourceTree = <group>; };
+	DF962B16DC574B18864520BB6C8F7B71 /* transport.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = transport.json; sourceTree = <group>; };
+	91C05ECBF1644A69BB0977C6EC8BB656 /* pois.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = pois.json; sourceTree = <group>; };
+	91072CA6FE4546D1B11A026EA69CFD82 /* esim_plans.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = esim_plans.json; sourceTree = <group>; };
+	9BDE6A65E50B42DAA7F0FCACE4E92175 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = <group>; };
+	6ADEDD1F99744762AAA2BC49BD418770 /* JourneyTH.xcdatamodeld */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodeld; path = JourneyTH.xcdatamodeld; sourceTree = <group>; };
+	AD9639B5FA9442EF8C93471C274351F2 /* TransportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportViewModelTests.swift; sourceTree = <group>; };
+	AFF06062C05041329C88A5C549D9C188 /* PoiViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoiViewModelTests.swift; sourceTree = <group>; };
+	F66E467385C24E37AC1397AF80F041C9 /* ItineraryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItineraryRepositoryTests.swift; sourceTree = <group>; };
+	52A4D820998E4546898C8695748D6604 /* OrderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderServiceTests.swift; sourceTree = <group>; };
+	2C5C847824774C5C86885E19AD6D7FAB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = <group>; };
+	B44213AB2E084C7DA4A40A73796DD149 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = <group>; };
+	EDEFAF81E471449BA01CDB83D7DE73CF /* JourneyTH.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = JourneyTH.app; sourceTree = BUILT_PRODUCTS_DIR; };
+	C460CDD0F8484BC9B1898F4E32831B7B /* JourneyTHTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = wrapper.cfbundle; path = JourneyTHTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+	1826E90C4AC3439983EB4553E23F8ED2 /* Frameworks */ = {
+		isa = PBXFrameworksBuildPhase;
+		buildActionMask = 2147483647;
+		files = (
+		);
+		runOnlyForDeploymentPostprocessing = 0;
+	};
+	C68CE1376718499FB02CD49079B41642 /* Frameworks */ = {
+		isa = PBXFrameworksBuildPhase;
+		buildActionMask = 2147483647;
+		files = (
+		);
+		runOnlyForDeploymentPostprocessing = 0;
+	};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+	C82283E8BE864528A747D2F7A83317C0 = {isa = PBXGroup;
+		children = (
+			0DB5D6543BA0449EB3D7BCAEA31D226B /* JourneyTH */,
+			15705C559F48472EAD723162B86AC98F /* Tests */,
+			462D4819A0CB4833AE150112EF7A29AB /* Products */,
+			49EE75DF10BF469FB5DB19617997EA50 /* Frameworks */,
+		);
+		sourceTree = <group>;
+	};
+	0DB5D6543BA0449EB3D7BCAEA31D226B = {isa = PBXGroup;
+		children = (
+			B1FAABA271344FB88FE4C5787F826043 /* JourneyTHApp.swift */,
+			992568F9E3514B579BFB32E8DC41C67B /* Features */,
+			64E0E4D8BF444CE7B22882C10CCBCC8E /* Models */,
+			4B25A2265D8A459BAA10F887997A1334 /* Services */,
+			F733CF0E84FC4FCA86536ADB9C26B44D /* Resources */,
+			47E0D37270D244A89682C822C4E78EF9 /* CoreData */,
+		);
+		name = JourneyTH;
+		path = JourneyTH;
+		sourceTree = <group>;
+	};
+	992568F9E3514B579BFB32E8DC41C67B = {isa = PBXGroup;
+		children = (
+			37354241611F45799E3D32649E675F99 /* Shared */,
+			86D459A535584AEA9C453098A55F57AB /* Transport */,
+			D4400F01B8A84115B9250B4CEEE7D245 /* Discover */,
+			C4F26EBE073C4274BB587AF2E33B10FD /* Itinerary */,
+			69D8BC34DE8E4CBDBD532E2AE86D0597 /* Esim */,
+			3DD0AAD2ED104C8081D3774D9D1F9C22 /* Payments */,
+			DC925BCF35A948FCA68A9EFA95DF95AC /* Account */,
+		);
+		name = Features;
+		path = Features;
+		sourceTree = <group>;
+	};
+	37354241611F45799E3D32649E675F99 = {isa = PBXGroup;
+		children = (
+			05C0BD92CD2642EFB42B64D0B096EDEE /* AppSettings.swift */,
+			C9BE5809471D4ACAA1CA31ABC1A828CF /* SharedComponents.swift */,
+		);
+		name = Shared;
+		path = Shared;
+		sourceTree = <group>;
+	};
+	86D459A535584AEA9C453098A55F57AB = {isa = PBXGroup;
+		children = (
+			76BAEE7AA8CD42888B6B8297F411B8A2 /* TransportFeature.swift */,
+		);
+		name = Transport;
+		path = Transport;
+		sourceTree = <group>;
+	};
+	D4400F01B8A84115B9250B4CEEE7D245 = {isa = PBXGroup;
+		children = (
+			C726873733654A5AAAF6C20DC82E409C /* DiscoverFeature.swift */,
+		);
+		name = Discover;
+		path = Discover;
+		sourceTree = <group>;
+	};
+	C4F26EBE073C4274BB587AF2E33B10FD = {isa = PBXGroup;
+		children = (
+			A56820073EF24CBD8E17952FC55E21CF /* ItineraryFeature.swift */,
+		);
+		name = Itinerary;
+		path = Itinerary;
+		sourceTree = <group>;
+	};
+	69D8BC34DE8E4CBDBD532E2AE86D0597 = {isa = PBXGroup;
+		children = (
+			E606100D0DF34F5294D288409D91ED2A /* EsimFeature.swift */,
+		);
+		name = Esim;
+		path = Esim;
+		sourceTree = <group>;
+	};
+	3DD0AAD2ED104C8081D3774D9D1F9C22 = {isa = PBXGroup;
+		children = (
+			5E07DDF5C5684C05B2C6180FD987004E /* PaymentsFeature.swift */,
+		);
+		name = Payments;
+		path = Payments;
+		sourceTree = <group>;
+	};
+	DC925BCF35A948FCA68A9EFA95DF95AC = {isa = PBXGroup;
+		children = (
+			BD8927F09F3C46BFA3E1AB54A2573C45 /* AccountFeature.swift */,
+		);
+		name = Account;
+		path = Account;
+		sourceTree = <group>;
+	};
+	64E0E4D8BF444CE7B22882C10CCBCC8E = {isa = PBXGroup;
+		children = (
+			F5A56803A65249C3A5630D2CC1411923 /* TransportRoute.swift */,
+			491BAA9C25A8486C8B4A912173BDFF9C /* Poi.swift */,
+			F458FA79BA7C4F54BE5D37BA6F10D472 /* EsimPlan.swift */,
+			5D77BEDAEFF74199B55147D585E814C2 /* OrderModel.swift */,
+		);
+		name = Models;
+		path = Models;
+		sourceTree = <group>;
+	};
+	4B25A2265D8A459BAA10F887997A1334 = {isa = PBXGroup;
+		children = (
+			F5E25C83484E4C5D85F2759A83C8B002 /* LocalDataLoader.swift */,
+			6CD204A9303E4AEA898B8870E6A3EA6A /* TransportService.swift */,
+			36EF10CCC0CE4398B9EB7064F895E64A /* PoiService.swift */,
+			16245B883427418D8E6EB5E715C2608D /* OrderService.swift */,
+			9A986428DD23477AAC6355BDD9A2D5C9 /* Persistence.swift */,
+			FC46CE28CE744A56B56D012F8855A4DA /* PlanLoader.swift */,
+		);
+		name = Services;
+		path = Services;
+		sourceTree = <group>;
+	};
+	F733CF0E84FC4FCA86536ADB9C26B44D = {isa = PBXGroup;
+		children = (
+			AA1467DA18A6437DB8006AD167FD3E01 /* Data */,
+			3E73571D642847898629AB66C51C48A9 /* Localizations */,
+			9BDE6A65E50B42DAA7F0FCACE4E92175 /* Assets.xcassets */,
+		);
+		name = Resources;
+		path = Resources;
+		sourceTree = <group>;
+	};
+	AA1467DA18A6437DB8006AD167FD3E01 = {isa = PBXGroup;
+		children = (
+			DF962B16DC574B18864520BB6C8F7B71 /* transport.json */,
+			91C05ECBF1644A69BB0977C6EC8BB656 /* pois.json */,
+			91072CA6FE4546D1B11A026EA69CFD82 /* esim_plans.json */,
+		);
+		name = Data;
+		path = Data;
+		sourceTree = <group>;
+	};
+	3E73571D642847898629AB66C51C48A9 = {isa = PBXGroup;
+		children = (
+			814928D0D8DD4EE3B92B8702FFA15231 /* Localizable.strings */,
+		);
+		name = Localizations;
+		path = Localizations;
+		sourceTree = <group>;
+	};
+	47E0D37270D244A89682C822C4E78EF9 = {isa = PBXGroup;
+		children = (
+			6ADEDD1F99744762AAA2BC49BD418770 /* JourneyTH.xcdatamodeld */,
+		);
+		name = CoreData;
+		path = CoreData;
+		sourceTree = <group>;
+	};
+	15705C559F48472EAD723162B86AC98F = {isa = PBXGroup;
+		children = (
+			AD9639B5FA9442EF8C93471C274351F2 /* TransportViewModelTests.swift */,
+			AFF06062C05041329C88A5C549D9C188 /* PoiViewModelTests.swift */,
+			F66E467385C24E37AC1397AF80F041C9 /* ItineraryRepositoryTests.swift */,
+			52A4D820998E4546898C8695748D6604 /* OrderServiceTests.swift */,
+		);
+		name = Tests;
+		path = Tests;
+		sourceTree = <group>;
+	};
+	462D4819A0CB4833AE150112EF7A29AB = {isa = PBXGroup;
+		children = (
+			EDEFAF81E471449BA01CDB83D7DE73CF /* JourneyTH.app */,
+			C460CDD0F8484BC9B1898F4E32831B7B /* JourneyTHTests.xctest */,
+		);
+		name = Products;
+		sourceTree = <group>;
+	};
+	49EE75DF10BF469FB5DB19617997EA50 = {isa = PBXGroup;
+		children = (
+		);
+		name = Frameworks;
+		sourceTree = <group>;
+	};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+	39B43CB0CC254B7EB0DC56A68B1B3DA8 /* JourneyTH */ = {isa = PBXNativeTarget; buildConfigurationList = A94D40C2F8FC42629F640CD095B796A5 /* Build configuration list for PBXNativeTarget "JourneyTH" */; buildPhases = (
+		1826E90C4AC3439983EB4553E23F8ED2 /* Frameworks */,
+		FCDB113566C3466AA3087BBD7DD45D58 /* Sources */,
+		9B844106FEE54C71BEEC7E23B667677E /* Resources */
+	); buildRules = (
+	); dependencies = (
+	); name = JourneyTH; productName = JourneyTH; productReference = EDEFAF81E471449BA01CDB83D7DE73CF /* JourneyTH.app */; productType = "com.apple.product-type.application"; };
+	7D5E5DEE4D09405DA95019C510A45B34 /* JourneyTHTests */ = {isa = PBXNativeTarget; buildConfigurationList = BA4170AD04464A4E9E8BC6AA57094B2D /* Build configuration list for PBXNativeTarget "JourneyTHTests" */; buildPhases = (
+		C68CE1376718499FB02CD49079B41642 /* Frameworks */,
+		0BA224D65BD8452A922D1A28C536C5DF /* Sources */,
+		4B95F9C09D234038868F3462F44F64AB /* Resources */
+	); buildRules = (
+	); dependencies = (
+	4359A57CB6D84B00A3060827FA3B678F /* PBXTargetDependency */
+	); name = JourneyTHTests; productName = JourneyTHTests; productReference = C460CDD0F8484BC9B1898F4E32831B7B /* JourneyTHTests.xctest */; productType = "com.apple.product-type.bundle.unit-test"; };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+	37088684A8C14E49AF159A3CB05ADBDB /* Project object */ = {isa = PBXProject; attributes = {BuildIndependentTargetsInParallel = YES; LastSwiftUpdateCheck = 1500; LastUpgradeCheck = 1500; TargetAttributes = {39B43CB0CC254B7EB0DC56A68B1B3DA8 = {CreatedOnToolsVersion = 15.0;}; 7D5E5DEE4D09405DA95019C510A45B34 = {CreatedOnToolsVersion = 15.0; TestTargetID = 39B43CB0CC254B7EB0DC56A68B1B3DA8;};};}; buildConfigurationList = 48FE4AC96B74498194B0D75F4A2105CF /* Build configuration list for PBXProject "JourneyTH" */; compatibilityVersion = "Xcode 15.0"; developmentRegion = en; hasScannedForEncodings = 0; knownRegions = (
+	en,
+	Base,
+	th
+	); mainGroup = C82283E8BE864528A747D2F7A83317C0; productRefGroup = 462D4819A0CB4833AE150112EF7A29AB; projectDirPath = ""; projectRoot = ""; targets = (
+	39B43CB0CC254B7EB0DC56A68B1B3DA8 /* JourneyTH */,
+	7D5E5DEE4D09405DA95019C510A45B34 /* JourneyTHTests */
+	); };
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+	9B844106FEE54C71BEEC7E23B667677E /* Resources */ = {
+		isa = PBXResourcesBuildPhase;
+		buildActionMask = 2147483647;
+		files = (
+			0B401BE29AC547BE97B2BBC9B6627BB6 /* transport.json in Resources */,
+			1B6300A431CB49C9B9C9AE33DFCDB2AA /* esim_plans.json in Resources */,
+			9DF485B541FB495BA3AB03F3FA70DAFE /* pois.json in Resources */,
+			5801E565694C43B4AEBD4E24883BDE5C /* Assets.xcassets in Resources */,
+			FF192049B2AC4E7BB21949AF6945662E /* JourneyTH.xcdatamodeld in Resources */,
+			A94D8F43BA194F0D94B5602F00D5F01E /* Localizable.strings in Resources */,
+		);
+		runOnlyForDeploymentPostprocessing = 0;
+	};
+	4B95F9C09D234038868F3462F44F64AB /* Resources */ = {
+		isa = PBXResourcesBuildPhase;
+		buildActionMask = 2147483647;
+		files = (
+		);
+		runOnlyForDeploymentPostprocessing = 0;
+	};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+	FCDB113566C3466AA3087BBD7DD45D58 /* Sources */ = {
+		isa = PBXSourcesBuildPhase;
+		buildActionMask = 2147483647;
+		files = (
+			4B108C3A7DAF479093E851E79F1FA206 /* JourneyTHApp.swift in Sources */,
+			0F94DB5B0FFD414B94AD397F66E56566 /* SharedComponents.swift in Sources */,
+			1929634F6BC04705965471981ED5791D /* PaymentsFeature.swift in Sources */,
+			2440393F08554AB9A76B5F8E2510A5BA /* PoiService.swift in Sources */,
+			45D007163FE0497FAB2C8BA754485F1C /* DiscoverFeature.swift in Sources */,
+			6EE7497C8BA94366BF71BADBAAB3B6D5 /* EsimPlan.swift in Sources */,
+			7488EBB0C5D04819A202E98D74273823 /* TransportService.swift in Sources */,
+			7A7795B785544A33BD9E6A684293CD1C /* TransportRoute.swift in Sources */,
+			8F7AD27BF2F4478791EAD2E08A94FB06 /* ItineraryFeature.swift in Sources */,
+			9B334F16F8394AE1A85A13EB87239E3D /* EsimFeature.swift in Sources */,
+			AA8829520D574593B2BE06F9A2D5252F /* Persistence.swift in Sources */,
+			B3E3EF69B8714C8EB3E12813A98B3C34 /* OrderModel.swift in Sources */,
+			BA964D783A6C4FC49CB22A946A016EB8 /* AccountFeature.swift in Sources */,
+			CA08AEE838414AAD8190629D7522D4D4 /* PlanLoader.swift in Sources */,
+			D079E00F5BFF442E8B3E058370F57DBD /* OrderService.swift in Sources */,
+			E12A73A08ECD47DF8681D9109908DC95 /* LocalDataLoader.swift in Sources */,
+			EF419844F2084FC0904F53003C96382B /* AppSettings.swift in Sources */,
+			F870F5C828DA4AE3A8AB3B43507FA391 /* TransportFeature.swift in Sources */,
+		);
+		runOnlyForDeploymentPostprocessing = 0;
+	};
+	0BA224D65BD8452A922D1A28C536C5DF /* Sources */ = {
+		isa = PBXSourcesBuildPhase;
+		buildActionMask = 2147483647;
+		files = (
+			A623F952FAFE4F3CB6B23909FC329D80 /* TransportViewModelTests.swift in Sources */,
+			6408A3AF5B424F7B8302A613E58108AF /* PoiViewModelTests.swift in Sources */,
+			3ABCFA3A7D0D4E4EAE2866772E2F8201 /* ItineraryRepositoryTests.swift in Sources */,
+			05833FE86B234D20AAE4651C70D84BE2 /* OrderServiceTests.swift in Sources */,
+		);
+		runOnlyForDeploymentPostprocessing = 0;
+	};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+	4359A57CB6D84B00A3060827FA3B678F /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = 39B43CB0CC254B7EB0DC56A68B1B3DA8 /* JourneyTH */; targetProxy = 0277F47312AB481FBD115BB4A9F61D96 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+	814928D0D8DD4EE3B92B8702FFA15231 /* Localizable.strings */ = {
+		isa = PBXVariantGroup;
+		children = (
+			2C5C847824774C5C86885E19AD6D7FAB /* en */,
+			B44213AB2E084C7DA4A40A73796DD149 /* th */,
+		);
+		name = Localizable.strings;
+		sourceTree = <group>;
+	};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+	745C0DB40D0B43FC9FEE81AF97CC6BBC /* Debug */ = {
+		isa = XCBuildConfiguration;
+		buildSettings = {
+			ALWAYS_SEARCH_USER_PATHS = NO;
+			CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+			CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+			DEBUG_INFORMATION_FORMAT = dwarf;
+			ENABLE_TESTABILITY = YES;
+			GCC_C_LANGUAGE_STANDARD = gnu17;
+			GCC_NO_COMMON_BLOCKS = YES;
+			GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+			GCC_WARN_UNDECLARED_SELECTOR = YES;
+			GCC_WARN_UNUSED_FUNCTION = YES;
+			GCC_WARN_UNUSED_VARIABLE = YES;
+			IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+			MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+			ONLY_ACTIVE_ARCH = YES;
+			SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+			SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			SWIFT_VERSION = 5.0;
+		};
+		name = Debug;
+	};
+	3ADF79AEEBEA4A0ABD6660461B4FFA29 /* Release */ = {
+		isa = XCBuildConfiguration;
+		buildSettings = {
+			ALWAYS_SEARCH_USER_PATHS = NO;
+			CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+			CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+			GCC_C_LANGUAGE_STANDARD = gnu17;
+			GCC_NO_COMMON_BLOCKS = YES;
+			GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+			GCC_WARN_UNDECLARED_SELECTOR = YES;
+			GCC_WARN_UNUSED_FUNCTION = YES;
+			GCC_WARN_UNUSED_VARIABLE = YES;
+			IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+			MTL_ENABLE_DEBUG_INFO = NO;
+			SWIFT_COMPILATION_MODE = wholemodule;
+			SWIFT_OPTIMIZATION_LEVEL = "-O";
+			SWIFT_VERSION = 5.0;
+			VALIDATE_PRODUCT = YES;
+		};
+		name = Release;
+	};
+	BD36F355AE5D404DB99FE11F5B38BE68 /* Debug */ = {
+		isa = XCBuildConfiguration;
+		buildSettings = {
+			ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+			CODE_SIGN_STYLE = Automatic;
+			CURRENT_PROJECT_VERSION = 1;
+			GENERATE_INFOPLIST_FILE = YES;
+			INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+			INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+			IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+			MARKETING_VERSION = 1.0;
+			PRODUCT_BUNDLE_IDENTIFIER = com.example.JourneyTH;
+			PRODUCT_NAME = "$(TARGET_NAME)";
+			SWIFT_EMIT_LOC_STRINGS = YES;
+			SWIFT_VERSION = 5.0;
+			TARGETED_DEVICE_FAMILY = 1;
+		};
+		name = Debug;
+	};
+	2A02174B22884437BA2130EFCF1DAA63 /* Release */ = {
+		isa = XCBuildConfiguration;
+		buildSettings = {
+			ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+			CODE_SIGN_STYLE = Automatic;
+			CURRENT_PROJECT_VERSION = 1;
+			GENERATE_INFOPLIST_FILE = YES;
+			INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+			INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+			IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+			MARKETING_VERSION = 1.0;
+			PRODUCT_BUNDLE_IDENTIFIER = com.example.JourneyTH;
+			PRODUCT_NAME = "$(TARGET_NAME)";
+			SWIFT_EMIT_LOC_STRINGS = YES;
+			SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+			SWIFT_VERSION = 5.0;
+			TARGETED_DEVICE_FAMILY = 1;
+		};
+		name = Release;
+	};
+	0B53C482991D4CB3A5D001140109523E /* Debug */ = {
+		isa = XCBuildConfiguration;
+		buildSettings = {
+			CODE_SIGN_STYLE = Automatic;
+			GENERATE_INFOPLIST_FILE = YES;
+			IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+			PRODUCT_BUNDLE_IDENTIFIER = com.example.JourneyTHTests;
+			PRODUCT_NAME = "$(TARGET_NAME)";
+			SWIFT_VERSION = 5.0;
+			TARGETED_DEVICE_FAMILY = 1;
+		};
+		name = Debug;
+	};
+	77E183D9A2774B0D8B985CED6707BC7F /* Release */ = {
+		isa = XCBuildConfiguration;
+		buildSettings = {
+			CODE_SIGN_STYLE = Automatic;
+			GENERATE_INFOPLIST_FILE = YES;
+			IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+			PRODUCT_BUNDLE_IDENTIFIER = com.example.JourneyTHTests;
+			PRODUCT_NAME = "$(TARGET_NAME)";
+			SWIFT_VERSION = 5.0;
+			TARGETED_DEVICE_FAMILY = 1;
+		};
+		name = Release;
+	};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+	48FE4AC96B74498194B0D75F4A2105CF /* Build configuration list for PBXProject "JourneyTH" */ = {isa = XCConfigurationList; buildConfigurations = (745C0DB40D0B43FC9FEE81AF97CC6BBC /* Debug */, 3ADF79AEEBEA4A0ABD6660461B4FFA29 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+	A94D40C2F8FC42629F640CD095B796A5 /* Build configuration list for PBXNativeTarget "JourneyTH" */ = {isa = XCConfigurationList; buildConfigurations = (BD36F355AE5D404DB99FE11F5B38BE68 /* Debug */, 2A02174B22884437BA2130EFCF1DAA63 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+	BA4170AD04464A4E9E8BC6AA57094B2D /* Build configuration list for PBXNativeTarget "JourneyTHTests" */ = {isa = XCConfigurationList; buildConfigurations = (0B53C482991D4CB3A5D001140109523E /* Debug */, 77E183D9A2774B0D8B985CED6707BC7F /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+	};
+	rootObject = 37088684A8C14E49AF159A3CB05ADBDB /* Project object */;
+}

--- a/JourneyTH/CoreData/JourneyTH.xcdatamodeld/JourneyTH.xcdatamodel/contents
+++ b/JourneyTH/CoreData/JourneyTH.xcdatamodeld/JourneyTH.xcdatamodel/contents
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="NO" userDefinedModelVersionIdentifier="">
+    <entity name="Itinerary" representedClassName="Itinerary" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUIDAttributeType" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="ItineraryItem" representedClassName="ItineraryItem" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="UUIDAttributeType" usesScalarValueType="NO"/>
+        <attribute name="itineraryId" optional="YES" attributeType="UUIDAttributeType" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0"/>
+        <attribute name="poiId" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="amountTHB" optional="YES" attributeType="Integer 32" defaultValueString="0"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUIDAttributeType" usesScalarValueType="NO"/>
+        <attribute name="planId" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="provider" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="status" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="type" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+    </entity>
+    <elements>
+        <element name="Itinerary" positionX="-63" positionY="-24" width="128" height="90"/>
+        <element name="ItineraryItem" positionX="113" positionY="0" width="128" height="105"/>
+        <element name="Order" positionX="-36" positionY="117" width="128" height="120"/>
+    </elements>
+</model>

--- a/JourneyTH/Features/Account/AccountFeature.swift
+++ b/JourneyTH/Features/Account/AccountFeature.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+@MainActor
+final class SettingsViewModel: ObservableObject {
+    @Published var useThai: Bool
+    @Published var message: String?
+
+    private let settings: AppSettings
+    private let orderService: OrderServicing
+    private let itineraryRepository: ItineraryRepository
+
+    init(settings: AppSettings, orderService: OrderServicing, itineraryRepository: ItineraryRepository) {
+        self.settings = settings
+        self.orderService = orderService
+        self.itineraryRepository = itineraryRepository
+        self.useThai = settings.useThai
+    }
+
+    func toggleLanguage(_ value: Bool) {
+        settings.useThai = value
+        useThai = value
+    }
+
+    func clearData() {
+        do {
+            try itineraryRepository.clearAll()
+            try orderService.clearOrders()
+            message = settings.localized("account.cleared")
+        } catch {
+            message = error.localizedDescription
+        }
+    }
+
+    var versionText: String {
+        settings.localized("account.version") + ": " + settings.appVersion
+    }
+}
+
+struct AccountView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        Form {
+            Section(header: Text(settings.localized("account.profile.section"))) {
+                HStack {
+                    Image(systemName: "person.crop.square")
+                        .font(.largeTitle)
+                        .foregroundStyle(.accent)
+                    VStack(alignment: .leading) {
+                        Text("JourneyTH Explorer")
+                            .font(.headline)
+                        Text(settings.localized("account.local.profile"))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Toggle(settings.localized("account.language.toggle"), isOn: Binding(
+                    get: { viewModel.useThai },
+                    set: { newValue in viewModel.toggleLanguage(newValue) }
+                ))
+                Text(viewModel.versionText)
+                    .font(.footnote)
+            }
+
+            Section(header: Text(settings.localized("account.settings.section"))) {
+                Button(role: .destructive) {
+                    Haptics.shared.play(.success)
+                    viewModel.clearData()
+                } label: {
+                    Text(settings.localized("account.clear.data"))
+                }
+            }
+            if let message = viewModel.message {
+                Section {
+                    Text(message)
+                }
+            }
+        }
+        .navigationTitle(settings.localized("account.title"))
+    }
+}

--- a/JourneyTH/Features/Discover/DiscoverFeature.swift
+++ b/JourneyTH/Features/Discover/DiscoverFeature.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+import MapKit
+
+@MainActor
+final class PoiViewModel: ObservableObject {
+    @Published private(set) var pois: [Poi] = []
+    @Published private(set) var filteredPois: [Poi] = []
+    @Published var selectedArea: String = ""
+    @Published var selectedTags: Set<String> = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    let areas = ["Bangkok", "Chiang Mai", "Phuket"]
+    let tags = ["Temple", "Food", "Market", "Night"]
+
+    private let service: PoiServiceProtocol
+    private let itineraryRepository: ItineraryRepository
+
+    init(service: PoiServiceProtocol, itineraryRepository: ItineraryRepository) {
+        self.service = service
+        self.itineraryRepository = itineraryRepository
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            let data = try await service.fetchPois()
+            pois = data
+            applyFilters()
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    func applyFilters() {
+        filteredPois = pois.filter { poi in
+            let matchesArea = selectedArea.isEmpty || poi.area == selectedArea
+            let matchesTags = selectedTags.isEmpty || !Set(poi.tags).isDisjoint(with: selectedTags)
+            return matchesArea && matchesTags
+        }
+    }
+
+    func addToItinerary(poi: Poi) {
+        do {
+            _ = try itineraryRepository.add(poi: poi)
+            Haptics.shared.play(.success)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func clearFilters() {
+        selectedArea = ""
+        selectedTags = []
+        applyFilters()
+    }
+}
+
+struct DiscoverView: View {
+    @ObservedObject var viewModel: PoiViewModel
+    @EnvironmentObject private var settings: AppSettings
+    @State private var displayMode: DisplayMode = .list
+
+    enum DisplayMode: String, CaseIterable, Identifiable {
+        case list
+        case map
+
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Picker(settings.localized("discover.toggle.title"), selection: $displayMode) {
+                Text(settings.localized("discover.toggle.list")).tag(DisplayMode.list)
+                Text(settings.localized("discover.toggle.map")).tag(DisplayMode.map)
+            }
+            .pickerStyle(.segmented)
+
+            PoiFilterBar(
+                selectedArea: $viewModel.selectedArea,
+                selectedTags: $viewModel.selectedTags,
+                areas: viewModel.areas,
+                tags: viewModel.tags,
+                resetTitle: settings.localized("discover.filter.reset"),
+                onReset: viewModel.clearFilters
+            )
+            .onChange(of: viewModel.selectedArea) { _ in viewModel.applyFilters() }
+            .onChange(of: viewModel.selectedTags) { _ in viewModel.applyFilters() }
+
+            Group {
+                switch displayMode {
+                case .list:
+                    if viewModel.filteredPois.isEmpty {
+                        EmptyStateView(
+                            title: settings.localized("discover.empty.title"),
+                            subtitle: settings.localized("discover.empty.subtitle"),
+                            imageSystemName: "safari",
+                            actionTitle: nil,
+                            action: nil
+                        )
+                    } else {
+                        List(viewModel.filteredPois) { poi in
+                            NavigationLink(destination: PoiDetailView(poi: poi, onAdd: { viewModel.addToItinerary(poi: poi) })) {
+                                PoiCard(
+                                    poi: poi,
+                                    minutesLabel: settings.localized("shared.minutes.unit"),
+                                    ratingLabel: settings.localized("discover.rating.label")
+                                )
+                            }
+                            .listRowInsets(EdgeInsets())
+                            .listRowBackground(Color.clear)
+                        }
+                        .listStyle(.plain)
+                        .refreshable {
+                            await viewModel.load()
+                        }
+                    }
+                case .map:
+                    Map(initialPosition: .automatic) {
+                        ForEach(viewModel.filteredPois) { poi in
+                            Annotation(poi.name, coordinate: poi.coordinate) {
+                                VStack {
+                                    Image(systemName: "mappin.circle.fill")
+                                        .font(.title2)
+                                        .foregroundStyle(.red)
+                                    Text(poi.name)
+                                        .font(.caption)
+                                        .fixedSize()
+                                }
+                                .padding(4)
+                                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                            }
+                        }
+                    }
+                    .mapStyle(.standard)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .accessibilityLabel(settings.localized("discover.map.accessibility"))
+                }
+            }
+        }
+        .padding()
+        .navigationTitle(settings.localized("discover.title"))
+        .task {
+            if viewModel.pois.isEmpty {
+                await viewModel.load()
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error = viewModel.errorMessage {
+                ErrorBanner(
+                    message: error,
+                    retryTitle: settings.localized("shared.try.again"),
+                    onRetry: { Task { await viewModel.load() } }
+                )
+                .padding()
+            }
+        }
+        .overlay {
+            if viewModel.isLoading {
+                LoadingOverlay(text: settings.localized("shared.loading"))
+            }
+        }
+    }
+}
+
+struct PoiDetailView: View {
+    let poi: Poi
+    let onAdd: () -> Void
+    @EnvironmentObject private var settings: AppSettings
+
+    private var slideKeys: [String] {
+        poi.images.isEmpty ? [poi.id] : poi.images
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                TabView {
+                    ForEach(slideKeys, id: \.self) { imageKey in
+                        PoiSymbolSlide(imageKey: imageKey, title: poi.name)
+                    }
+                }
+                .tabViewStyle(.page)
+                .frame(height: 240)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(poi.name)
+                        .font(.title.bold())
+                    Text(poi.area)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    RatingRow(rating: poi.rating, localizedLabel: settings.localized("discover.rating.label"))
+                    Text("\(poi.minutes) \(settings.localized("shared.minutes.unit"))")
+                        .font(.headline)
+                    HStack {
+                        ForEach(poi.tags, id: \.self) { TagChip(text: $0) }
+                    }
+                    Button(settings.localized("add.to.itinerary")) {
+                        Haptics.shared.play(.success)
+                        onAdd()
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                }
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+            }
+            .padding()
+        }
+        .navigationTitle(poi.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/JourneyTH/Features/Esim/EsimFeature.swift
+++ b/JourneyTH/Features/Esim/EsimFeature.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import CoreImage.CIFilterBuiltins
+
+@MainActor
+final class EsimViewModel: ObservableObject {
+    @Published private(set) var plans: [EsimPlan] = []
+    @Published private(set) var latestOrder: OrderModel?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let planLoader: PlanLoading
+    private let orderService: OrderServicing
+    private let paymentProvider: PaymentProviding
+    private let context = CIContext()
+
+    init(planLoader: PlanLoading, orderService: OrderServicing, paymentProvider: PaymentProviding) {
+        self.planLoader = planLoader
+        self.orderService = orderService
+        self.paymentProvider = paymentProvider
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            plans = try await planLoader.fetchPlans()
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    func refreshOrders(for plan: EsimPlan?) {
+        do {
+            if let plan {
+                latestOrder = try orderService.latestOrder(for: plan)
+            } else {
+                latestOrder = try orderService.fetchOrders().first
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func createOrder(for plan: EsimPlan) async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            let order = try await orderService.createOrder(for: plan, provider: paymentProvider)
+            latestOrder = order
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    func markActivated() async {
+        guard let order = latestOrder else { return }
+        do {
+            let status = await paymentProvider.markPaid(order: order)
+            latestOrder = try orderService.markOrder(order.id, as: status)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func qrImage() -> UIImage? {
+        guard let order = latestOrder else { return nil }
+        let filter = CIFilter.qrCodeGenerator()
+        let payload = "plan=\(order.planId)&order=\(order.id.uuidString)"
+        filter.setValue(Data(payload.utf8), forKey: "inputMessage")
+        guard let output = filter.outputImage else { return nil }
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: 8, y: 8))
+        if let cgImage = context.createCGImage(scaled, from: scaled.extent) {
+            return UIImage(cgImage: cgImage)
+        }
+        return nil
+    }
+}
+
+struct EsimView: View {
+    @ObservedObject var viewModel: EsimViewModel
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if viewModel.plans.isEmpty {
+                EmptyStateView(
+                    title: settings.localized("esim.title"),
+                    subtitle: settings.localized("esim.empty.subtitle"),
+                    imageSystemName: "simcard.fill",
+                    actionTitle: nil,
+                    action: nil
+                )
+            } else {
+                List(viewModel.plans) { plan in
+                    NavigationLink(destination: EsimPlanDetailView(plan: plan, viewModel: viewModel)) {
+                        EsimPlanRow(plan: plan)
+                    }
+                    .listRowBackground(Color.clear)
+                }
+                .listStyle(.plain)
+            }
+        }
+        .padding()
+        .navigationTitle(settings.localized("esim.title"))
+        .task {
+            if viewModel.plans.isEmpty {
+                await viewModel.load()
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error = viewModel.errorMessage {
+                ErrorBanner(
+                    message: error,
+                    retryTitle: settings.localized("shared.try.again"),
+                    onRetry: { Task { await viewModel.load() } }
+                )
+                .padding()
+            }
+        }
+        .overlay {
+            if viewModel.isLoading {
+                LoadingOverlay(text: settings.localized("shared.loading"))
+            }
+        }
+    }
+}
+
+struct EsimPlanRow: View {
+    let plan: EsimPlan
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(plan.name)
+                    .font(.headline)
+                Spacer()
+                Text("฿\(plan.priceTHB)")
+                    .font(.headline)
+            }
+            Text(plan.network)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("\(plan.validityDays) days • \(plan.speed)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+struct EsimPlanDetailView: View {
+    let plan: EsimPlan
+    @ObservedObject var viewModel: EsimViewModel
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(plan.name)
+                        .font(.largeTitle.bold())
+                    Text(plan.network)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                    Text(settings.localized("esim.plan.price") + ": ฿\(plan.priceTHB)")
+                        .font(.headline)
+                    Text("\(settings.localized("esim.plan.validity")) \(plan.validityDays) \(settings.localized("shared.days"))")
+                        .font(.headline)
+                    Text(settings.localized("esim.plan.speed"))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(plan.speed)
+                        .font(.body)
+                }
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+
+                if let order = viewModel.latestOrder {
+                    OrderStatusView(order: order, qrImage: viewModel.qrImage(), onMarkActivated: {
+                        Task { await viewModel.markActivated() }
+                    })
+                } else {
+                    Button(settings.localized("esim.plan.purchase")) {
+                        Task { await viewModel.createOrder(for: plan) }
+                        Haptics.shared.play(.success)
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                }
+            }
+            .padding()
+        }
+        .navigationTitle(plan.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            viewModel.refreshOrders(for: plan)
+        }
+    }
+}

--- a/JourneyTH/Features/Itinerary/ItineraryFeature.swift
+++ b/JourneyTH/Features/Itinerary/ItineraryFeature.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+struct ItineraryDisplayItem: Identifiable, Equatable {
+    let id: UUID
+    let poi: Poi
+    let order: Int
+}
+
+@MainActor
+final class ItineraryViewModel: ObservableObject {
+    @Published private(set) var items: [ItineraryDisplayItem] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var shareText: String = ""
+
+    private let repository: ItineraryRepository
+    private let poiService: PoiServiceProtocol
+    private var cachedPois: [Poi] = []
+
+    init(repository: ItineraryRepository, poiService: PoiServiceProtocol) {
+        self.repository = repository
+        self.poiService = poiService
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            cachedPois = try await poiService.fetchPois()
+            let stored = try repository.items()
+            items = stored.compactMap { model in
+                guard let poi = cachedPois.first(where: { $0.id == model.poiId }) else { return nil }
+                return ItineraryDisplayItem(id: model.id, poi: poi, order: model.order)
+            }.sorted(by: { $0.order < $1.order })
+            shareText = makeShareText()
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    func remove(_ item: ItineraryDisplayItem) {
+        do {
+            _ = try repository.remove(itemId: item.id)
+            Task { await load() }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func move(from source: IndexSet, to destination: Int) {
+        do {
+            _ = try repository.reorder(from: source, to: destination)
+            Task { await load() }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func clear() {
+        do {
+            try repository.clearAll()
+            Task { await load() }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func totalMinutes() -> Int {
+        items.reduce(0) { $0 + $1.poi.minutes }
+    }
+
+    private func makeShareText() -> String {
+        items.sorted(by: { $0.order < $1.order }).enumerated().map { index, item in
+            "Day \(index + 1): \(item.poi.name) - \(item.poi.minutes) minutes"
+        }.joined(separator: "\n")
+    }
+}
+
+struct ItineraryView: View {
+    @ObservedObject var viewModel: ItineraryViewModel
+    @EnvironmentObject private var settings: AppSettings
+    @State private var showShare = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if viewModel.items.isEmpty {
+                EmptyStateView(
+                    title: settings.localized("itinerary.empty.title"),
+                    subtitle: settings.localized("itinerary.empty.subtitle"),
+                    imageSystemName: "calendar",
+                    actionTitle: settings.localized("itinerary.cta.discover"),
+                    action: nil
+                )
+            } else {
+                List {
+                    ForEach(viewModel.items) { item in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.poi.name)
+                                    .font(.headline)
+                                Text("\(item.poi.minutes) \(settings.localized("shared.minutes.unit"))")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                Text(item.poi.area)
+                                    .font(.caption)
+                            }
+                            Spacer()
+                            Button(role: .destructive) {
+                                viewModel.remove(item)
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                            .accessibilityLabel(settings.localized("itinerary.remove.accessibility"))
+                        }
+                    }
+                    .onMove(perform: viewModel.move)
+                }
+                .listStyle(.insetGrouped)
+                .toolbar { EditButton() }
+
+                HStack {
+                    Text("\(settings.localized("itinerary.total.minutes")) \(viewModel.totalMinutes())")
+                        .font(.headline)
+                    Spacer()
+                    ShareLink(item: viewModel.shareText) {
+                        Label(settings.localized("itinerary.share"), systemImage: "square.and.arrow.up")
+                    }
+                }
+                Button(role: .destructive) {
+                    viewModel.clear()
+                } label: {
+                    Text(settings.localized("account.clear.data"))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding()
+        .navigationTitle(settings.localized("itinerary.title"))
+        .task {
+            await viewModel.load()
+        }
+        .refreshable {
+            await viewModel.load()
+        }
+        .overlay {
+            if viewModel.isLoading {
+                LoadingOverlay(text: settings.localized("shared.loading"))
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error = viewModel.errorMessage {
+                ErrorBanner(
+                    message: error,
+                    retryTitle: settings.localized("shared.try.again"),
+                    onRetry: { Task { await viewModel.load() } }
+                )
+                .padding()
+            }
+        }
+    }
+}

--- a/JourneyTH/Features/Payments/PaymentsFeature.swift
+++ b/JourneyTH/Features/Payments/PaymentsFeature.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct OrderStatusView: View {
+    let order: OrderModel
+    let qrImage: UIImage?
+    let onMarkActivated: () -> Void
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text(settings.localized("esim.order.status"))
+                    .font(.headline)
+                Spacer()
+                StatusBadge(status: order.status)
+            }
+            Text("฿\(order.amountTHB)")
+                .font(.title2.bold())
+            Text(settings.localized("esim.qr.instructions"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            QRPreviewView(
+                image: qrImage,
+                title: settings.localized(order.status.localizedKey),
+                subtitle: settings.localized("esim.order.created") + " " + order.createdAt.formatted(date: .abbreviated, time: .shortened)
+            )
+            Button(settings.localized("esim.order.mark.activated")) {
+                Haptics.shared.play(.success)
+                onMarkActivated()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .disabled(order.status == .paid)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+struct StatusBadge: View {
+    let status: OrderStatus
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        Text(settings.localized(status.localizedKey))
+            .font(.caption.bold())
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(backgroundColor.opacity(0.2))
+            .foregroundStyle(backgroundColor)
+            .clipShape(Capsule())
+    }
+
+    private var backgroundColor: Color {
+        switch status {
+        case .pending: return .orange
+        case .paid: return .green
+        case .failed: return .red
+        }
+    }
+}

--- a/JourneyTH/Features/Shared/AppSettings.swift
+++ b/JourneyTH/Features/Shared/AppSettings.swift
@@ -1,0 +1,109 @@
+import Foundation
+import SwiftUI
+import Combine
+import CoreData
+import UIKit
+
+final class AppSettings: ObservableObject {
+    @AppStorage(Self.languageKey) private var storedLanguage: String = "en"
+
+    @Published var locale: Locale
+    @Published var useThai: Bool {
+        didSet {
+            let code = useThai ? "th" : "en"
+            storedLanguage = code
+            applyLanguage(code)
+        }
+    }
+
+    private static let languageKey = "selectedLanguage"
+
+    init() {
+        let initialCode = Self.resolveLanguageCode(from: storedLanguage)
+        storedLanguage = initialCode
+        self.locale = Locale(identifier: initialCode)
+        self.useThai = initialCode == "th"
+    }
+
+    func localized(_ key: String) -> String {
+        LocalizationManager.shared.localizedString(forKey: key)
+    }
+
+    var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    private func applyLanguage(_ code: String) {
+        LocalizationManager.shared.setLanguage(code)
+        locale = Locale(identifier: code)
+    }
+
+    private static func resolveLanguageCode(from stored: String) -> String {
+        if stored == "th" || stored == "en" {
+            return stored
+        }
+        return Locale.current.identifier.hasPrefix("th") ? "th" : "en"
+    }
+}
+
+final class LocalizationManager {
+    static let shared = LocalizationManager()
+    private var bundle: Bundle = .main
+    private var languageCode: String = Locale.current.identifier
+
+    private init() {}
+
+    func setLanguage(_ code: String) {
+        languageCode = code
+        if let path = Bundle.main.path(forResource: code, ofType: "lproj"),
+           let bundle = Bundle(path: path) {
+            self.bundle = bundle
+        } else {
+            self.bundle = .main
+        }
+    }
+
+    func localizedString(forKey key: String) -> String {
+        bundle.localizedString(forKey: key, value: nil, table: nil)
+    }
+
+    var locale: Locale {
+        Locale(identifier: languageCode)
+    }
+}
+
+final class ServiceContainer: ObservableObject {
+    static let shared = ServiceContainer()
+
+    let persistence: PersistenceController
+    let transportService: TransportServiceProtocol
+    let poiService: PoiServiceProtocol
+    let orderService: OrderServicing
+    let itineraryRepository: ItineraryRepository
+    let planLoader: PlanLoading
+    let paymentProvider: PaymentProviding
+
+    private init() {
+        let persistence = PersistenceController.shared
+        self.persistence = persistence
+
+        let dataLoader = LocalDataLoader()
+        self.transportService = MockTransportService(loader: dataLoader)
+        self.poiService = MockPoiService(loader: dataLoader)
+        self.itineraryRepository = ItineraryRepository(context: persistence.container.viewContext)
+        self.planLoader = LocalPlanLoader(loader: dataLoader)
+        self.paymentProvider = MockPaymentProvider()
+        self.orderService = OrderService(context: persistence.container.viewContext)
+    }
+}
+
+final class Haptics {
+    static let shared = Haptics()
+    private init() {}
+
+    func play(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+}

--- a/JourneyTH/Features/Shared/SharedComponents.swift
+++ b/JourneyTH/Features/Shared/SharedComponents.swift
@@ -1,0 +1,451 @@
+import SwiftUI
+import MapKit
+
+struct PrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Color.accentColor)
+            .foregroundStyle(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .opacity(configuration.isPressed ? 0.8 : 1)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+struct TagChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(Color.secondary.opacity(0.15))
+            .clipShape(Capsule())
+            .accessibilityLabel(Text(text))
+    }
+}
+
+struct RatingRow: View {
+    let rating: Double
+    let localizedLabel: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "star.fill")
+                .foregroundStyle(.yellow)
+            Text(String(format: "%.1f", rating))
+                .font(.subheadline.bold())
+            Text(localizedLabel)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(localizedLabel) \(rating)")
+    }
+}
+
+struct PriceBadge: View {
+    let price: String
+
+    var body: some View {
+        Text(price)
+            .font(.caption.bold())
+            .padding(6)
+            .background(Color.green.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
+struct EmptyStateView: View {
+    let title: String
+    let subtitle: String
+    let imageSystemName: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: imageSystemName)
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.title2.bold())
+                .multilineTextAlignment(.center)
+            Text(subtitle)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            if let actionTitle, let action {
+                Button(actionTitle, action: {
+                    Haptics.shared.play(.success)
+                    action()
+                })
+                .buttonStyle(PrimaryButtonStyle())
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+}
+
+struct RouteStepRow: View {
+    let step: TransportStep
+
+    var body: some View {
+        HStack {
+            Image(systemName: iconName(for: step.mode))
+                .foregroundStyle(.accent)
+            Text(step.name)
+                .font(.body)
+            Spacer()
+            Text(step.mode)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(step.mode) - \(step.name)")
+    }
+
+    private func iconName(for mode: String) -> String {
+        switch mode.lowercased() {
+        case "train": return "train.side.front.car"
+        case "bus": return "bus"
+        case "ferry": return "ferry"
+        case "walk": return "figure.walk"
+        default: return "arrowshape.turn.up.right"
+        }
+    }
+}
+
+struct PoiCard: View {
+    let poi: Poi
+    let minutesLabel: String
+    let ratingLabel: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            PoiSymbolBadge(imageKey: poi.images.first ?? poi.id)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(poi.name)
+                        .font(.headline)
+                    Spacer()
+                    RatingRow(rating: poi.rating, localizedLabel: ratingLabel)
+                }
+                Text(poi.area)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("\(poi.minutes) \(minutesLabel)")
+                    .font(.subheadline)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        ForEach(poi.tags, id: \.self) { tag in
+                            TagChip(text: tag)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(poi.name), \(poi.area), \(poi.rating)")
+    }
+}
+
+struct PoiSymbolBadge: View {
+    let imageKey: String
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(PoiSymbolPalette.gradient(for: imageKey))
+                .frame(width: 56, height: 56)
+            Image(systemName: PoiSymbolPalette.symbol(for: imageKey))
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
+        }
+    }
+}
+
+struct PoiFilterBar: View {
+    @Binding var selectedArea: String
+    @Binding var selectedTags: Set<String>
+    let areas: [String]
+    let tags: [String]
+    let resetTitle: String
+    let onReset: () -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                Menu {
+                    Picker("Area", selection: $selectedArea) {
+                        Text(resetTitle).tag("")
+                        ForEach(areas, id: \.self) { area in
+                            Text(area).tag(area)
+                        }
+                    }
+                } label: {
+                    Label(selectedArea.isEmpty ? resetTitle : selectedArea, systemImage: "mappin.and.ellipse")
+                        .padding(8)
+                        .background(Color(.tertiarySystemFill))
+                        .clipShape(Capsule())
+                }
+
+                Menu {
+                    ForEach(tags, id: \.self) { tag in
+                        Button {
+                            toggle(tag: tag)
+                        } label: {
+                            HStack {
+                                Text(tag)
+                                if selectedTags.contains(tag) {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Label(selectedTags.isEmpty ? resetTitle : selectedTags.joined(separator: ", "), systemImage: "line.3.horizontal.decrease.circle")
+                        .padding(8)
+                        .background(Color(.tertiarySystemFill))
+                        .clipShape(Capsule())
+                }
+
+                Button(resetTitle) {
+                    selectedArea = ""
+                    selectedTags = []
+                    onReset()
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    private func toggle(tag: String) {
+        if selectedTags.contains(tag) {
+            selectedTags.remove(tag)
+        } else {
+            selectedTags.insert(tag)
+        }
+    }
+}
+
+struct PoiSymbolSlide: View {
+    let imageKey: String
+    let title: String
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(PoiSymbolPalette.gradient(for: imageKey))
+            Image(systemName: PoiSymbolPalette.symbol(for: imageKey))
+                .font(.system(size: 96, weight: .semibold))
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.2), radius: 12, x: 0, y: 6)
+        }
+        .frame(height: 220)
+        .padding(.horizontal)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(title))
+    }
+}
+
+enum PoiSymbolPalette {
+    static func symbol(for key: String) -> String {
+        switch key {
+        case "wat_arun": return "sunrise.fill"
+        case "chatuchak": return "cart.fill"
+        case "chinatown": return "fork.knife.circle.fill"
+        case "bua_tong": return "leaf.fill"
+        case "doi_suthep": return "figure.hiking"
+        case "nimman": return "sparkles"
+        case "patong": return "sun.max.fill"
+        case "phi_phi": return "water.waves"
+        case "old_phuket": return "building.2.fill"
+        case "asiatique": return "bag.fill"
+        case "mae_kampong": return "leaf.circle.fill"
+        case "karon": return "binoculars.fill"
+        default: return "mappin.circle.fill"
+        }
+    }
+
+    static func gradient(for key: String) -> LinearGradient {
+        let colors: [Color]
+        switch key {
+        case "wat_arun":
+            colors = [.orange, .pink]
+        case "chatuchak":
+            colors = [.green, .mint]
+        case "chinatown":
+            colors = [.red, .orange]
+        case "bua_tong":
+            colors = [.green, .teal]
+        case "doi_suthep":
+            colors = [.purple, .blue]
+        case "nimman":
+            colors = [.indigo, .pink]
+        case "patong":
+            colors = [.yellow, .orange]
+        case "phi_phi":
+            colors = [.teal, .blue]
+        case "old_phuket":
+            colors = [.blue, .purple]
+        case "asiatique":
+            colors = [.pink, .orange]
+        case "mae_kampong":
+            colors = [.green, .brown]
+        case "karon":
+            colors = [.cyan, .blue]
+        default:
+            colors = [.teal, .blue]
+        }
+        return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+}
+
+struct QRPreviewView: View {
+    let image: UIImage?
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .interpolation(.none)
+                    .scaledToFit()
+                    .frame(width: 220, height: 220)
+                    .accessibilityLabel(Text(title))
+            } else {
+                ProgressView()
+            }
+            Text(title)
+                .font(.title3.bold())
+            Text(subtitle)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+}
+
+struct MapRouteView: View {
+    let coordinates: [CLLocationCoordinate2D]
+    let title: String
+    let originTitle: String
+    let destinationTitle: String
+
+    var body: some View {
+        Map(initialPosition: .region(region)) {
+            if coordinates.count > 1 {
+                MapPolyline(coordinates)
+                    .stroke(.blue, lineWidth: 4)
+            }
+            if let startCoordinate {
+                Annotation(originTitle, coordinate: startCoordinate) {
+                    annotationView(title: originTitle, color: .green)
+                }
+            }
+            if let endCoordinate {
+                Annotation(destinationTitle, coordinate: endCoordinate) {
+                    annotationView(title: destinationTitle, color: .red)
+                }
+            }
+        }
+        .mapStyle(.standard)
+        .overlay(alignment: .topLeading) {
+            Text(title)
+                .font(.headline)
+                .padding(8)
+                .background(.thinMaterial, in: Capsule())
+                .padding()
+        }
+        .accessibilityLabel(Text(title))
+    }
+
+    private var region: MKCoordinateRegion {
+        guard let first = coordinates.first else {
+            return MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 13.7563, longitude: 100.5018), span: MKCoordinateSpan(latitudeDelta: 0.2, longitudeDelta: 0.2))
+        }
+        var minLat = first.latitude
+        var maxLat = first.latitude
+        var minLon = first.longitude
+        var maxLon = first.longitude
+        for coordinate in coordinates.dropFirst() {
+            minLat = min(minLat, coordinate.latitude)
+            maxLat = max(maxLat, coordinate.latitude)
+            minLon = min(minLon, coordinate.longitude)
+            maxLon = max(maxLon, coordinate.longitude)
+        }
+        let center = CLLocationCoordinate2D(latitude: (minLat + maxLat) / 2, longitude: (minLon + maxLon) / 2)
+        let span = MKCoordinateSpan(latitudeDelta: max(0.01, maxLat - minLat + 0.02), longitudeDelta: max(0.01, maxLon - minLon + 0.02))
+        return MKCoordinateRegion(center: center, span: span)
+    }
+
+    private var startCoordinate: CLLocationCoordinate2D? { coordinates.first }
+    private var endCoordinate: CLLocationCoordinate2D? { coordinates.last }
+
+    private func annotationView(title: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: "mappin.circle.fill")
+                .font(.title2)
+                .foregroundStyle(color)
+            Text(title)
+                .font(.caption)
+                .padding(6)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+    }
+}
+
+struct LoadingOverlay: View {
+    let text: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text(text)
+                .font(.subheadline)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(.thinMaterial))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+    }
+}
+
+struct ErrorBanner: View {
+    let message: String
+    let retryTitle: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+            Text(message)
+                .font(.body)
+            Spacer()
+            Button(retryTitle, action: onRetry)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.red.opacity(0.1)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+    }
+}

--- a/JourneyTH/Features/Transport/TransportFeature.swift
+++ b/JourneyTH/Features/Transport/TransportFeature.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+import MapKit
+
+@MainActor
+final class TransportViewModel: ObservableObject {
+    @Published var origin: String = "Bangkok"
+    @Published var destination: String = "Siam"
+    @Published var travelDate: Date = .now
+    @Published private(set) var routes: [TransportRoute] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private var searchTask: Task<Void, Never>?
+    private let service: TransportServiceProtocol
+
+    init(service: TransportServiceProtocol) {
+        self.service = service
+    }
+
+    func loadInitial() {
+        search()
+    }
+
+    func search() {
+        searchTask?.cancel()
+        isLoading = true
+        errorMessage = nil
+        let origin = origin
+        let destination = destination
+        searchTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let results = try await service.searchRoutes(from: origin, to: destination)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    self.routes = results
+                    self.isLoading = false
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+}
+
+struct TransportView: View {
+    @ObservedObject var viewModel: TransportViewModel
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            searchForm
+            if viewModel.routes.isEmpty {
+                EmptyStateView(
+                    title: settings.localized("transport.title"),
+                    subtitle: settings.localized("transport.search.empty"),
+                    imageSystemName: "tram.fill",
+                    actionTitle: settings.localized("transport.search.button"),
+                    action: viewModel.search
+                )
+            } else {
+                List(viewModel.routes) { route in
+                    NavigationLink(destination: TransportDetailView(route: route, travelDate: viewModel.travelDate)) {
+                        TransportRouteRow(route: route)
+                    }
+                    .listRowBackground(Color.clear)
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .padding()
+        .navigationTitle(settings.localized("transport.title"))
+        .task {
+            if viewModel.routes.isEmpty {
+                viewModel.loadInitial()
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error = viewModel.errorMessage {
+                ErrorBanner(
+                    message: error,
+                    retryTitle: settings.localized("shared.try.again"),
+                    onRetry: viewModel.search
+                )
+                .padding()
+            }
+        }
+        .overlay {
+            if viewModel.isLoading {
+                LoadingOverlay(text: settings.localized("shared.loading"))
+            }
+        }
+    }
+
+    private var searchForm: some View {
+        VStack(spacing: 12) {
+            TextField(settings.localized("transport.origin.placeholder"), text: $viewModel.origin)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.words)
+            TextField(settings.localized("transport.destination.placeholder"), text: $viewModel.destination)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.words)
+            DatePicker(settings.localized("transport.travel.date"), selection: $viewModel.travelDate, displayedComponents: [.date, .hourAndMinute])
+                .datePickerStyle(.compact)
+            Button(settings.localized("transport.search.button")) {
+                Haptics.shared.play(.success)
+                viewModel.search()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+    }
+}
+
+struct TransportRouteRow: View {
+    let route: TransportRoute
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(route.origin) → \(route.destination)")
+                        .font(.headline)
+                    Text("\(settings.localized("transport.duration")) \(route.formattedDuration)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                PriceBadge(price: route.formattedPrice)
+            }
+            HStack {
+                ForEach(route.steps) { step in
+                    TagChip(text: step.mode)
+                }
+            }
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(route.origin) to \(route.destination) \(route.formattedDuration) \(route.formattedPrice)")
+    }
+}
+
+struct TransportDetailView: View {
+    let route: TransportRoute
+    let travelDate: Date
+    @EnvironmentObject private var settings: AppSettings
+    @State private var showFullMap = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if !route.coordinates.isEmpty {
+                    MapRouteView(
+                        coordinates: route.coordinates,
+                        title: "\(route.origin) → \(route.destination)",
+                        originTitle: route.origin,
+                        destinationTitle: route.destination
+                    )
+                        .frame(height: 240)
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        .padding(.top)
+                    Button {
+                        Haptics.shared.play(.success)
+                        showFullMap = true
+                    } label: {
+                        Label(settings.localized("transport.view.map"), systemImage: "map")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                travelInfo
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(settings.localized("transport.steps.title"))
+                        .font(.title3.bold())
+                    ForEach(route.steps) { step in
+                        RouteStepRow(step: step)
+                        Divider()
+                    }
+                }
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+            }
+            .padding()
+        }
+        .navigationTitle("\(route.origin) → \(route.destination)")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showFullMap) {
+            NavigationStack {
+                MapRouteView(
+                    coordinates: route.coordinates,
+                    title: "\(route.origin) → \(route.destination)",
+                    originTitle: route.origin,
+                    destinationTitle: route.destination
+                )
+                .ignoresSafeArea(edges: .bottom)
+                .navigationTitle(settings.localized("transport.view.map"))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(settings.localized("shared.close")) {
+                            showFullMap = false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension TransportDetailView {
+    var travelInfo: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "calendar.badge.clock")
+                .font(.title2)
+                .foregroundStyle(.accent)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(settings.localized("transport.travel.date"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text(travelDate.formatted(date: .abbreviated, time: .shortened))
+                    .font(.headline)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(settings.localized("transport.travel.date")) \(travelDate.formatted(date: .abbreviated, time: .shortened))")
+    }
+}

--- a/JourneyTH/JourneyTHApp.swift
+++ b/JourneyTH/JourneyTHApp.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import CoreData
+import MapKit
+
+@main
+struct JourneyTHApp: App {
+    @StateObject private var settings = AppSettings()
+    private let persistenceController = PersistenceController.shared
+
+    var body: some Scene {
+        WindowGroup {
+            MainTabView()
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                .environmentObject(settings)
+                .environmentObject(ServiceContainer.shared)
+                .environment(\.locale, settings.locale)
+        }
+    }
+}
+
+struct MainTabView: View {
+    @EnvironmentObject private var settings: AppSettings
+    @EnvironmentObject private var container: ServiceContainer
+    @State private var showAccount = false
+
+    var body: some View {
+        TabView {
+            NavigationStack {
+                TransportView(viewModel: TransportViewModel(service: container.transportService))
+                    .toolbar {
+                        accountButton
+                    }
+            }
+            .tabItem {
+                Label(settings.localized("transport.title"), systemImage: "tram.fill")
+            }
+
+            NavigationStack {
+                DiscoverView(viewModel: PoiViewModel(service: container.poiService, itineraryRepository: container.itineraryRepository))
+                    .toolbar {
+                        accountButton
+                    }
+            }
+            .tabItem {
+                Label(settings.localized("discover.title"), systemImage: "map")
+            }
+
+            NavigationStack {
+                ItineraryView(viewModel: ItineraryViewModel(repository: container.itineraryRepository, poiService: container.poiService))
+                    .toolbar {
+                        accountButton
+                    }
+            }
+            .tabItem {
+                Label(settings.localized("itinerary.title"), systemImage: "list.bullet.rectangle")
+            }
+
+            NavigationStack {
+                EsimView(viewModel: EsimViewModel(planLoader: container.planLoader, orderService: container.orderService, paymentProvider: container.paymentProvider))
+                    .toolbar {
+                        accountButton
+                    }
+            }
+            .tabItem {
+                Label(settings.localized("esim.title"), systemImage: "simcard")
+            }
+        }
+        .sheet(isPresented: $showAccount) {
+            NavigationStack {
+                AccountView(viewModel: SettingsViewModel(settings: settings, orderService: container.orderService, itineraryRepository: container.itineraryRepository))
+            }
+        }
+    }
+
+    private var accountButton: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                showAccount.toggle()
+                Haptics.shared.play(.success)
+            } label: {
+                Image(systemName: "person.crop.circle")
+                    .accessibilityLabel(settings.localized("account.title"))
+            }
+        }
+    }
+}

--- a/JourneyTH/Models/EsimPlan.swift
+++ b/JourneyTH/Models/EsimPlan.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct EsimPlan: Identifiable, Codable, Equatable {
+    let id: String
+    let name: String
+    let network: String
+    let priceTHB: Int
+    let speed: String
+    let validityDays: Int
+}

--- a/JourneyTH/Models/OrderModel.swift
+++ b/JourneyTH/Models/OrderModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum OrderStatus: String, CaseIterable, Codable {
+    case pending
+    case paid
+    case failed
+
+    var localizedKey: String {
+        switch self {
+        case .pending: return "esim.order.pending"
+        case .paid: return "esim.order.paid"
+        case .failed: return "esim.order.failed"
+        }
+    }
+}
+
+struct OrderModel: Identifiable, Equatable {
+    let id: UUID
+    let type: String
+    let amountTHB: Int
+    var status: OrderStatus
+    let provider: String
+    let createdAt: Date
+    let planId: String
+}

--- a/JourneyTH/Models/Poi.swift
+++ b/JourneyTH/Models/Poi.swift
@@ -1,0 +1,18 @@
+import Foundation
+import MapKit
+
+struct Poi: Identifiable, Codable, Equatable {
+    let id: String
+    let name: String
+    let area: String
+    let rating: Double
+    let tags: [String]
+    let minutes: Int
+    let latitude: Double
+    let longitude: Double
+    let images: [String]
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}

--- a/JourneyTH/Models/TransportRoute.swift
+++ b/JourneyTH/Models/TransportRoute.swift
@@ -1,0 +1,44 @@
+import Foundation
+import MapKit
+
+struct TransportRoute: Identifiable, Codable, Equatable {
+    let id: String
+    let origin: String
+    let destination: String
+    let durationMinutes: Int
+    let priceTHB: Double
+    let steps: [TransportStep]
+    let polyline: [RouteCoordinate]?
+
+    var formattedDuration: String {
+        let hours = durationMinutes / 60
+        let minutes = durationMinutes % 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var formattedPrice: String {
+        String(format: "฿%.0f", priceTHB)
+    }
+
+    var coordinates: [CLLocationCoordinate2D] {
+        (polyline ?? []).map { $0.location }
+    }
+}
+
+struct TransportStep: Identifiable, Codable, Equatable {
+    var id: String { name + mode }
+    let mode: String
+    let name: String
+}
+
+struct RouteCoordinate: Codable, Equatable {
+    let latitude: Double
+    let longitude: Double
+
+    var location: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}

--- a/JourneyTH/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JourneyTH/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,17 @@
+{
+  "images" : [
+    {
+      "filename" : "Icon.svg",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "properties" : {
+    "preserves-vector-representation" : true
+  },
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JourneyTH/Resources/Assets.xcassets/AppIcon.appiconset/Icon.svg
+++ b/JourneyTH/Resources/Assets.xcassets/AppIcon.appiconset/Icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#1D4ED8" />
+    </linearGradient>
+  </defs>
+  <rect width="1024" height="1024" rx="220" fill="url(#bg)" />
+  <text x="50%" y="55%" font-family="SFProRounded-Bold, 'SF Pro Rounded', 'Helvetica Neue', Arial, sans-serif" font-size="380" font-weight="700" fill="#FFFFFF" text-anchor="middle">JT</text>
+</svg>

--- a/JourneyTH/Resources/Assets.xcassets/Contents.json
+++ b/JourneyTH/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JourneyTH/Resources/Data/esim_plans.json
+++ b/JourneyTH/Resources/Data/esim_plans.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ais_5gb_7d",
+    "name": "AIS Explorer",
+    "network": "AIS",
+    "priceTHB": 299,
+    "speed": "5GB high-speed then 128kbps",
+    "validityDays": 7
+  },
+  {
+    "id": "true_15gb_15d",
+    "name": "True Traveler",
+    "network": "True",
+    "priceTHB": 499,
+    "speed": "15GB high-speed then 256kbps",
+    "validityDays": 15
+  },
+  {
+    "id": "dtac_unlimited_8d",
+    "name": "dtac Unlimited",
+    "network": "dtac",
+    "priceTHB": 399,
+    "speed": "Unlimited 10Mbps",
+    "validityDays": 8
+  }
+]

--- a/JourneyTH/Resources/Data/pois.json
+++ b/JourneyTH/Resources/Data/pois.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": "poi_wat_arun",
+    "name": "Wat Arun",
+    "area": "Bangkok",
+    "rating": 4.8,
+    "tags": ["Temple", "River"],
+    "minutes": 90,
+    "latitude": 13.7437,
+    "longitude": 100.4880,
+    "images": ["wat_arun"]
+  },
+  {
+    "id": "poi_chatuchak",
+    "name": "Chatuchak Market",
+    "area": "Bangkok",
+    "rating": 4.6,
+    "tags": ["Market", "Food"],
+    "minutes": 180,
+    "latitude": 13.7994,
+    "longitude": 100.5507,
+    "images": ["chatuchak"]
+  },
+  {
+    "id": "poi_chinatown",
+    "name": "Yaowarat Chinatown",
+    "area": "Bangkok",
+    "rating": 4.7,
+    "tags": ["Food", "Night"],
+    "minutes": 120,
+    "latitude": 13.7394,
+    "longitude": 100.5107,
+    "images": ["chinatown"]
+  },
+  {
+    "id": "poi_bua_tong",
+    "name": "Bua Tong Sticky Waterfall",
+    "area": "Chiang Mai",
+    "rating": 4.9,
+    "tags": ["Nature"],
+    "minutes": 150,
+    "latitude": 19.0675,
+    "longitude": 99.1915,
+    "images": ["bua_tong"]
+  },
+  {
+    "id": "poi_doi_suthep",
+    "name": "Doi Suthep",
+    "area": "Chiang Mai",
+    "rating": 4.8,
+    "tags": ["Temple", "Nature"],
+    "minutes": 160,
+    "latitude": 18.8045,
+    "longitude": 98.9215,
+    "images": ["doi_suthep"]
+  },
+  {
+    "id": "poi_nimmanhaemin",
+    "name": "Nimmanhaemin Road",
+    "area": "Chiang Mai",
+    "rating": 4.4,
+    "tags": ["Food", "Night"],
+    "minutes": 90,
+    "latitude": 18.8021,
+    "longitude": 98.9677,
+    "images": ["nimman"]
+  },
+  {
+    "id": "poi_patong",
+    "name": "Patong Beach",
+    "area": "Phuket",
+    "rating": 4.3,
+    "tags": ["Night", "Beach"],
+    "minutes": 180,
+    "latitude": 7.8966,
+    "longitude": 98.2956,
+    "images": ["patong"]
+  },
+  {
+    "id": "poi_phi_phi",
+    "name": "Phi Phi Islands",
+    "area": "Phuket",
+    "rating": 4.9,
+    "tags": ["Nature", "Snorkel"],
+    "minutes": 480,
+    "latitude": 7.7407,
+    "longitude": 98.7784,
+    "images": ["phi_phi"]
+  },
+  {
+    "id": "poi_old_phuket",
+    "name": "Old Phuket Town",
+    "area": "Phuket",
+    "rating": 4.5,
+    "tags": ["Food", "Market"],
+    "minutes": 150,
+    "latitude": 7.8840,
+    "longitude": 98.3852,
+    "images": ["old_phuket"]
+  },
+  {
+    "id": "poi_asia_tique",
+    "name": "Asiatique The Riverfront",
+    "area": "Bangkok",
+    "rating": 4.4,
+    "tags": ["Night", "Market"],
+    "minutes": 150,
+    "latitude": 13.7042,
+    "longitude": 100.5105,
+    "images": ["asiatique"]
+  },
+  {
+    "id": "poi_mae_kampong",
+    "name": "Mae Kampong Village",
+    "area": "Chiang Mai",
+    "rating": 4.7,
+    "tags": ["Nature", "Culture"],
+    "minutes": 240,
+    "latitude": 18.8666,
+    "longitude": 99.3687,
+    "images": ["mae_kampong"]
+  },
+  {
+    "id": "poi_karon",
+    "name": "Karon Viewpoint",
+    "area": "Phuket",
+    "rating": 4.6,
+    "tags": ["Nature", "View"],
+    "minutes": 90,
+    "latitude": 7.8058,
+    "longitude": 98.3090,
+    "images": ["karon"]
+  }
+]

--- a/JourneyTH/Resources/Data/transport.json
+++ b/JourneyTH/Resources/Data/transport.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "bkk_siam_bts",
+    "origin": "Bangkok Station",
+    "destination": "Siam",
+    "durationMinutes": 25,
+    "priceTHB": 42,
+    "steps": [
+      { "mode": "Train", "name": "BTS Sukhumvit Line" },
+      { "mode": "Walk", "name": "Siam Paragon" }
+    ],
+    "polyline": [
+      { "latitude": 13.736717, "longitude": 100.523186 },
+      { "latitude": 13.745327, "longitude": 100.533889 },
+      { "latitude": 13.746535, "longitude": 100.534698 }
+    ]
+  },
+  {
+    "id": "dmk_riverside",
+    "origin": "Don Mueang Airport",
+    "destination": "Chao Phraya Riverside",
+    "durationMinutes": 60,
+    "priceTHB": 150,
+    "steps": [
+      { "mode": "Bus", "name": "A4 Airport Shuttle" },
+      { "mode": "Ferry", "name": "Chao Phraya Express" },
+      { "mode": "Walk", "name": "Riverside Hotel" }
+    ],
+    "polyline": [
+      { "latitude": 13.9125, "longitude": 100.6067 },
+      { "latitude": 13.7804, "longitude": 100.5405 },
+      { "latitude": 13.7260, "longitude": 100.5130 }
+    ]
+  },
+  {
+    "id": "bkk_ayutthaya",
+    "origin": "Bangkok",
+    "destination": "Ayutthaya",
+    "durationMinutes": 90,
+    "priceTHB": 250,
+    "steps": [
+      { "mode": "Train", "name": "State Railway" },
+      { "mode": "Bus", "name": "Ayutthaya Shuttle" }
+    ],
+    "polyline": [
+      { "latitude": 13.7563, "longitude": 100.5018 },
+      { "latitude": 14.3519, "longitude": 100.5774 }
+    ]
+  },
+  {
+    "id": "bkk_pattaya",
+    "origin": "Bangkok",
+    "destination": "Pattaya Beach",
+    "durationMinutes": 120,
+    "priceTHB": 320,
+    "steps": [
+      { "mode": "Bus", "name": "Ekamai Eastern Bus Terminal" },
+      { "mode": "Walk", "name": "Beach Road" }
+    ],
+    "polyline": [
+      { "latitude": 13.7249, "longitude": 100.4930 },
+      { "latitude": 12.9236, "longitude": 100.8825 }
+    ]
+  },
+  {
+    "id": "siam_icon",
+    "origin": "Siam",
+    "destination": "ICONSIAM",
+    "durationMinutes": 30,
+    "priceTHB": 70,
+    "steps": [
+      { "mode": "Train", "name": "BTS Silom Line" },
+      { "mode": "Ferry", "name": "ICONSIAM Shuttle Boat" }
+    ],
+    "polyline": [
+      { "latitude": 13.7450, "longitude": 100.5347 },
+      { "latitude": 13.7261, "longitude": 100.5101 }
+    ]
+  },
+  {
+    "id": "chiangmai_oldtown",
+    "origin": "Chiang Mai Airport",
+    "destination": "Old Town",
+    "durationMinutes": 35,
+    "priceTHB": 120,
+    "steps": [
+      { "mode": "Bus", "name": "Airport Smart Bus" },
+      { "mode": "Walk", "name": "Tha Phae Gate" }
+    ],
+    "polyline": [
+      { "latitude": 18.7724, "longitude": 98.9684 },
+      { "latitude": 18.7883, "longitude": 98.9986 }
+    ]
+  }
+]

--- a/JourneyTH/Resources/Localizations/en.lproj/Localizable.strings
+++ b/JourneyTH/Resources/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,58 @@
+"transport.title" = "Find Routes";
+"transport.search.empty" = "Search for Bangkok routes and get travel tips.";
+"transport.search.button" = "Search";
+"transport.origin.placeholder" = "Origin";
+"transport.destination.placeholder" = "Destination";
+"transport.duration" = "Duration";
+"transport.steps.title" = "Steps";
+"transport.travel.date" = "Departure time";
+"transport.view.map" = "View Map";
+
+"discover.title" = "Discover";
+"discover.toggle.title" = "Display";
+"discover.toggle.list" = "List";
+"discover.toggle.map" = "Map";
+"discover.filter.reset" = "All";
+"discover.empty.title" = "No results";
+"discover.empty.subtitle" = "Try adjusting filters to see more experiences.";
+"discover.rating.label" = "Rating";
+"discover.map.accessibility" = "Point of interest map";
+
+"add.to.itinerary" = "Add to Itinerary";
+
+"itinerary.title" = "My Itinerary";
+"itinerary.empty.title" = "Plan your trip";
+"itinerary.empty.subtitle" = "Add highlights from Discover to craft your journey.";
+"itinerary.cta.discover" = "Browse Discover";
+"itinerary.total.minutes" = "Total minutes";
+"itinerary.share" = "Share";
+"itinerary.remove.accessibility" = "Remove from itinerary";
+
+"esim.title" = "eSIM & Payments";
+"esim.empty.subtitle" = "Choose a plan to get started.";
+"esim.plan.price" = "Price";
+"esim.plan.validity" = "Validity";
+"esim.plan.speed" = "Speed";
+"esim.plan.purchase" = "Purchase Plan";
+"esim.order.status" = "Order Status";
+"esim.qr.instructions" = "Scan the QR code to install your eSIM.";
+"esim.order.created" = "Created";
+"esim.order.mark.activated" = "Mark as Activated";
+"esim.order.pending" = "Pending";
+"esim.order.paid" = "Activated";
+"esim.order.failed" = "Failed";
+
+"account.title" = "Account";
+"account.profile.section" = "Profile";
+"account.local.profile" = "Offline profile";
+"account.language.toggle" = "Use Thai language";
+"account.settings.section" = "Settings";
+"account.clear.data" = "Clear local data";
+"account.version" = "Version";
+"account.cleared" = "Data cleared";
+
+"shared.try.again" = "Try Again";
+"shared.loading" = "Loading";
+"shared.minutes.unit" = "mins";
+"shared.days" = "days";
+"shared.close" = "Close";

--- a/JourneyTH/Resources/Localizations/th.lproj/Localizable.strings
+++ b/JourneyTH/Resources/Localizations/th.lproj/Localizable.strings
@@ -1,0 +1,58 @@
+"transport.title" = "ค้นหาเส้นทาง";
+"transport.search.empty" = "ลองค้นหาเส้นทางในกรุงเทพฯ และดูคำแนะนำการเดินทาง";
+"transport.search.button" = "ค้นหา";
+"transport.origin.placeholder" = "ต้นทาง";
+"transport.destination.placeholder" = "ปลายทาง";
+"transport.duration" = "ระยะเวลา";
+"transport.steps.title" = "ขั้นตอนการเดินทาง";
+"transport.travel.date" = "เวลาออกเดินทาง";
+"transport.view.map" = "ดูแผนที่";
+
+"discover.title" = "สำรวจสถานที่";
+"discover.toggle.title" = "มุมมอง";
+"discover.toggle.list" = "รายการ";
+"discover.toggle.map" = "แผนที่";
+"discover.filter.reset" = "ทั้งหมด";
+"discover.empty.title" = "ไม่พบข้อมูล";
+"discover.empty.subtitle" = "ปรับตัวกรองเพื่อดูประสบการณ์เพิ่มเติม";
+"discover.rating.label" = "เรตติ้ง";
+"discover.map.accessibility" = "แผนที่สถานที่ท่องเที่ยว";
+
+"add.to.itinerary" = "เพิ่มในทริป";
+
+"itinerary.title" = "ทริปของฉัน";
+"itinerary.empty.title" = "เริ่มวางแผนทริป";
+"itinerary.empty.subtitle" = "เพิ่มไฮไลต์จากหน้าสำรวจเพื่อสร้างทริปของคุณ";
+"itinerary.cta.discover" = "ไปที่สำรวจสถานที่";
+"itinerary.total.minutes" = "เวลารวม";
+"itinerary.share" = "แชร์";
+"itinerary.remove.accessibility" = "ลบออกจากทริป";
+
+"esim.title" = "eSIM & ชำระเงิน";
+"esim.empty.subtitle" = "เลือกแพ็กเกจเพื่อเริ่มต้น";
+"esim.plan.price" = "ราคา";
+"esim.plan.validity" = "ระยะเวลา";
+"esim.plan.speed" = "ความเร็ว";
+"esim.plan.purchase" = "ซื้อแพ็กเกจ";
+"esim.order.status" = "สถานะคำสั่งซื้อ";
+"esim.qr.instructions" = "สแกน QR เพื่อดาวน์โหลด eSIM";
+"esim.order.created" = "สร้างเมื่อ";
+"esim.order.mark.activated" = "บันทึกว่าเปิดใช้งานแล้ว";
+"esim.order.pending" = "รอดำเนินการ";
+"esim.order.paid" = "เปิดใช้งาน";
+"esim.order.failed" = "ล้มเหลว";
+
+"account.title" = "บัญชี";
+"account.profile.section" = "โปรไฟล์";
+"account.local.profile" = "โปรไฟล์ในเครื่อง";
+"account.language.toggle" = "ใช้ภาษาไทย";
+"account.settings.section" = "การตั้งค่า";
+"account.clear.data" = "ลบข้อมูลในเครื่อง";
+"account.version" = "เวอร์ชัน";
+"account.cleared" = "ล้างข้อมูลแล้ว";
+
+"shared.try.again" = "ลองใหม่";
+"shared.loading" = "กำลังโหลด";
+"shared.minutes.unit" = "นาที";
+"shared.days" = "วัน";
+"shared.close" = "ปิด";

--- a/JourneyTH/Services/LocalDataLoader.swift
+++ b/JourneyTH/Services/LocalDataLoader.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol DataLoading {
+    func load<T: Decodable>(_ filename: String, as type: T.Type) throws -> T
+}
+
+struct LocalDataLoader: DataLoading {
+    private final class BundleMarker {}
+
+    func load<T: Decodable>(_ filename: String, as type: T.Type) throws -> T {
+        let bundle = Bundle.main.path(forResource: filename, ofType: "json") != nil ? Bundle.main : Bundle(for: BundleMarker.self)
+        guard let url = bundle.url(forResource: filename, withExtension: "json") else {
+            throw DataLoaderError.fileNotFound(filename)
+        }
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+enum DataLoaderError: Error {
+    case fileNotFound(String)
+}

--- a/JourneyTH/Services/OrderService.swift
+++ b/JourneyTH/Services/OrderService.swift
@@ -1,0 +1,100 @@
+import Foundation
+import CoreData
+
+protocol OrderServicing {
+    @MainActor
+    func createOrder(for plan: EsimPlan, provider: PaymentProviding) async throws -> OrderModel
+    @MainActor
+    func markOrder(_ id: UUID, as status: OrderStatus) throws -> OrderModel
+    @MainActor
+    func fetchOrders() throws -> [OrderModel]
+    @MainActor
+    func latestOrder(for plan: EsimPlan) throws -> OrderModel?
+    @MainActor
+    func clearOrders() throws
+}
+
+protocol PaymentProviding {
+    func initiatePayment(amount: Int) async -> OrderStatus
+    func markPaid(order: OrderModel) async -> OrderStatus
+}
+
+struct MockPaymentProvider: PaymentProviding {
+    func initiatePayment(amount: Int) async -> OrderStatus {
+        await Task.sleep(UInt64(0.2 * 1_000_000_000))
+        return .pending
+    }
+
+    func markPaid(order: OrderModel) async -> OrderStatus {
+        await Task.sleep(UInt64(0.1 * 1_000_000_000))
+        return .paid
+    }
+}
+
+@MainActor
+final class OrderService: OrderServicing {
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func createOrder(for plan: EsimPlan, provider: PaymentProviding) async throws -> OrderModel {
+        let status = await provider.initiatePayment(amount: plan.priceTHB)
+        let order = Order(context: context)
+        order.id = UUID()
+        order.amountTHB = Int32(plan.priceTHB)
+        order.type = "esim"
+        order.status = status.rawValue
+        order.provider = "MockPay"
+        order.createdAt = Date()
+        order.planId = plan.id
+        try context.save()
+        return try makeModel(from: order)
+    }
+
+    func markOrder(_ id: UUID, as status: OrderStatus) throws -> OrderModel {
+        let fetchRequest: NSFetchRequest<Order> = Order.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        guard let order = try context.fetch(fetchRequest).first else {
+            throw NSError(domain: "OrderService", code: 1)
+        }
+        order.status = status.rawValue
+        try context.save()
+        return try makeModel(from: order)
+    }
+
+    func fetchOrders() throws -> [OrderModel] {
+        let request: NSFetchRequest<Order> = Order.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: false)]
+        return try context.fetch(request).map { try makeModel(from: $0) }
+    }
+
+    func latestOrder(for plan: EsimPlan) throws -> OrderModel? {
+        let request: NSFetchRequest<Order> = Order.fetchRequest()
+        request.predicate = NSPredicate(format: "planId == %@", plan.id)
+        request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: false)]
+        request.fetchLimit = 1
+        return try context.fetch(request).first.flatMap { try? makeModel(from: $0) }
+    }
+
+    func clearOrders() throws {
+        let request: NSFetchRequest<NSFetchRequestResult> = Order.fetchRequest()
+        let batch = NSBatchDeleteRequest(fetchRequest: request)
+        try context.execute(batch)
+        try context.save()
+    }
+
+    private func makeModel(from managedObject: Order) throws -> OrderModel {
+        guard let id = managedObject.id,
+              let type = managedObject.type,
+              let statusRaw = managedObject.status,
+              let status = OrderStatus(rawValue: statusRaw),
+              let provider = managedObject.provider,
+              let createdAt = managedObject.createdAt,
+              let planId = managedObject.planId else {
+            throw NSError(domain: "OrderService", code: 2)
+        }
+        return OrderModel(id: id, type: type, amountTHB: Int(managedObject.amountTHB), status: status, provider: provider, createdAt: createdAt, planId: planId)
+    }
+}

--- a/JourneyTH/Services/Persistence.swift
+++ b/JourneyTH/Services/Persistence.swift
@@ -1,0 +1,129 @@
+import Foundation
+import CoreData
+
+final class PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "JourneyTH")
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Unresolved error \(error)")
+            }
+        }
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+}
+
+struct ItineraryItemModel: Identifiable, Equatable {
+    let id: UUID
+    let poiId: String
+    let order: Int
+}
+
+@MainActor
+final class ItineraryRepository {
+    private let context: NSManagedObjectContext
+    private var itinerary: Itinerary
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+        self.itinerary = ItineraryRepository.ensureItinerary(in: context)
+    }
+
+    private static func ensureItinerary(in context: NSManagedObjectContext) -> Itinerary {
+        let request: NSFetchRequest<Itinerary> = Itinerary.fetchRequest()
+        request.fetchLimit = 1
+        if let existing = try? context.fetch(request).first {
+            return existing
+        }
+        let itinerary = Itinerary(context: context)
+        itinerary.id = UUID()
+        itinerary.title = "Journey"
+        itinerary.createdAt = Date()
+        try? context.save()
+        return itinerary
+    }
+
+    func items() throws -> [ItineraryItemModel] {
+        let request: NSFetchRequest<ItineraryItem> = ItineraryItem.fetchRequest()
+        request.predicate = NSPredicate(format: "itineraryId == %@", itinerary.id! as CVarArg)
+        request.sortDescriptors = [NSSortDescriptor(key: "order", ascending: true)]
+        return try context.fetch(request).compactMap { item in
+            guard let id = item.id, let poiId = item.poiId else { return nil }
+            return ItineraryItemModel(id: id, poiId: poiId, order: Int(item.order))
+        }
+    }
+
+    func add(poi: Poi) throws -> [ItineraryItemModel] {
+        let item = ItineraryItem(context: context)
+        item.id = UUID()
+        item.poiId = poi.id
+        item.itineraryId = itinerary.id
+        let fetchRequest: NSFetchRequest<ItineraryItem> = ItineraryItem.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "itineraryId == %@", itinerary.id! as CVarArg)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "order", ascending: false)]
+        fetchRequest.fetchLimit = 1
+        let lastOrderValue = Int(try context.fetch(fetchRequest).first?.order ?? -1)
+        item.order = Int16(lastOrderValue + 1)
+        try context.save()
+        return try items()
+    }
+
+    func remove(itemId: UUID) throws -> [ItineraryItemModel] {
+        let request: NSFetchRequest<ItineraryItem> = ItineraryItem.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", itemId as CVarArg)
+        let results = try context.fetch(request)
+        for item in results {
+            context.delete(item)
+        }
+        try context.save()
+        return try normalizeOrders()
+    }
+
+    func reorder(from source: IndexSet, to destination: Int) throws -> [ItineraryItemModel] {
+        var current = try items()
+        current.move(fromOffsets: source, toOffset: destination)
+        for (index, model) in current.enumerated() {
+            let request: NSFetchRequest<ItineraryItem> = ItineraryItem.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", model.id as CVarArg)
+            if let item = try context.fetch(request).first {
+                item.order = Int16(index)
+            }
+        }
+        try context.save()
+        return try items()
+    }
+
+    func clearAll() throws {
+        let request: NSFetchRequest<NSFetchRequestResult> = ItineraryItem.fetchRequest()
+        let batch = NSBatchDeleteRequest(fetchRequest: request)
+        try context.execute(batch)
+        try context.save()
+    }
+
+    func totalMinutes(from pois: [Poi]) throws -> Int {
+        let items = try self.items()
+        let map = Dictionary(uniqueKeysWithValues: pois.map { ($0.id, $0) })
+        return items.compactMap { map[$0.poiId]?.minutes }.reduce(0, +)
+    }
+
+    private func normalizeOrders() throws -> [ItineraryItemModel] {
+        let current = try items().sorted { $0.order < $1.order }
+        for (index, model) in current.enumerated() {
+            let request: NSFetchRequest<ItineraryItem> = ItineraryItem.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", model.id as CVarArg)
+            if let item = try context.fetch(request).first {
+                item.order = Int16(index)
+            }
+        }
+        try context.save()
+        return try items()
+    }
+}

--- a/JourneyTH/Services/PlanLoader.swift
+++ b/JourneyTH/Services/PlanLoader.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+protocol PlanLoading {
+    func fetchPlans() async throws -> [EsimPlan]
+}
+
+struct LocalPlanLoader: PlanLoading {
+    let loader: DataLoading
+
+    init(loader: DataLoading) {
+        self.loader = loader
+    }
+
+    func fetchPlans() async throws -> [EsimPlan] {
+        try loader.load("esim_plans", as: [EsimPlan].self)
+    }
+}

--- a/JourneyTH/Services/PoiService.swift
+++ b/JourneyTH/Services/PoiService.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+protocol PoiServiceProtocol {
+    func fetchPois() async throws -> [Poi]
+    func poi(with id: String) async throws -> Poi?
+}
+
+actor PoiStore {
+    private var cached: [Poi]?
+
+    func set(_ pois: [Poi]) { cached = pois }
+    func all() -> [Poi]? { cached }
+    func get(id: String) -> Poi? { cached?.first { $0.id == id } }
+}
+
+struct MockPoiService: PoiServiceProtocol {
+    private let loader: DataLoading
+    private let store = PoiStore()
+
+    init(loader: DataLoading) {
+        self.loader = loader
+    }
+
+    func fetchPois() async throws -> [Poi] {
+        if let cached = await store.all() {
+            return cached
+        }
+        let pois: [Poi] = try loader.load("pois", as: [Poi].self)
+        await store.set(pois)
+        return pois
+    }
+
+    func poi(with id: String) async throws -> Poi? {
+        if let cached = await store.get(id: id) {
+            return cached
+        }
+        let pois = try await fetchPois()
+        return pois.first { $0.id == id }
+    }
+}

--- a/JourneyTH/Services/TransportService.swift
+++ b/JourneyTH/Services/TransportService.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+protocol TransportServiceProtocol {
+    func fetchRoutes() async throws -> [TransportRoute]
+    func searchRoutes(from origin: String, to destination: String) async throws -> [TransportRoute]
+}
+
+actor TransportRouteStore {
+    private var cachedRoutes: [TransportRoute]?
+
+    func cached() -> [TransportRoute]? { cachedRoutes }
+    func set(_ routes: [TransportRoute]) { cachedRoutes = routes }
+}
+
+struct MockTransportService: TransportServiceProtocol {
+    private let loader: DataLoading
+    private let store = TransportRouteStore()
+
+    init(loader: DataLoading) {
+        self.loader = loader
+    }
+
+    func fetchRoutes() async throws -> [TransportRoute] {
+        if let cached = await store.cached() {
+            return cached
+        }
+        let routes: [TransportRoute] = try loader.load("transport", as: [TransportRoute].self)
+        await store.set(routes)
+        return routes
+    }
+
+    func searchRoutes(from origin: String, to destination: String) async throws -> [TransportRoute] {
+        let routes = try await fetchRoutes()
+        let trimmedOrigin = origin.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmedDestination = destination.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        guard !trimmedOrigin.isEmpty || !trimmedDestination.isEmpty else {
+            return routes
+        }
+
+        return routes.filter { route in
+            let originMatch = trimmedOrigin.isEmpty || route.origin.lowercased().contains(trimmedOrigin)
+            let destinationMatch = trimmedDestination.isEmpty || route.destination.lowercased().contains(trimmedDestination)
+            return originMatch && destinationMatch
+        }
+    }
+}

--- a/JourneyTH/Tests/ItineraryRepositoryTests.swift
+++ b/JourneyTH/Tests/ItineraryRepositoryTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import JourneyTH
+
+@MainActor
+final class ItineraryRepositoryTests: XCTestCase {
+    private var repository: ItineraryRepository!
+
+    override func setUp() async throws {
+        let persistence = PersistenceController(inMemory: true)
+        repository = ItineraryRepository(context: persistence.container.viewContext)
+    }
+
+    func testAddAndFetchItems() throws {
+        let poi = Poi(id: "test", name: "Test", area: "Bangkok", rating: 4.0, tags: ["Food"], minutes: 60, latitude: 0, longitude: 0, images: [])
+        let items = try repository.add(poi: poi)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.poiId, "test")
+    }
+
+    func testReorderChangesOrder() throws {
+        let first = Poi(id: "first", name: "First", area: "Bangkok", rating: 4.2, tags: [], minutes: 30, latitude: 0, longitude: 0, images: [])
+        let second = Poi(id: "second", name: "Second", area: "Bangkok", rating: 4.1, tags: [], minutes: 40, latitude: 0, longitude: 0, images: [])
+        _ = try repository.add(poi: first)
+        _ = try repository.add(poi: second)
+        let updated = try repository.reorder(from: IndexSet(integer: 0), to: 2)
+        XCTAssertEqual(updated.first?.poiId, "second")
+    }
+
+    func testTotalMinutesMatchesSum() throws {
+        let poiA = Poi(id: "a", name: "A", area: "Bangkok", rating: 4.0, tags: [], minutes: 30, latitude: 0, longitude: 0, images: [])
+        let poiB = Poi(id: "b", name: "B", area: "Bangkok", rating: 4.0, tags: [], minutes: 45, latitude: 0, longitude: 0, images: [])
+        _ = try repository.add(poi: poiA)
+        _ = try repository.add(poi: poiB)
+        let total = try repository.totalMinutes(from: [poiA, poiB])
+        XCTAssertEqual(total, 75)
+    }
+}

--- a/JourneyTH/Tests/OrderServiceTests.swift
+++ b/JourneyTH/Tests/OrderServiceTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import JourneyTH
+
+@MainActor
+final class OrderServiceTests: XCTestCase {
+    private var service: OrderService!
+    private var provider: MockPaymentProvider!
+
+    override func setUp() async throws {
+        let persistence = PersistenceController(inMemory: true)
+        service = OrderService(context: persistence.container.viewContext)
+        provider = MockPaymentProvider()
+    }
+
+    func testCreateOrderIsPending() async throws {
+        let plan = EsimPlan(id: "test", name: "Test", network: "Mock", priceTHB: 100, speed: "Fast", validityDays: 3)
+        let order = try await service.createOrder(for: plan, provider: provider)
+        XCTAssertEqual(order.status, .pending)
+        XCTAssertEqual(order.amountTHB, 100)
+    }
+
+    func testMarkActivatedTransitionsToPaid() async throws {
+        let plan = EsimPlan(id: "test", name: "Test", network: "Mock", priceTHB: 100, speed: "Fast", validityDays: 3)
+        let order = try await service.createOrder(for: plan, provider: provider)
+        let updated = try service.markOrder(order.id, as: .paid)
+        XCTAssertEqual(updated.status, .paid)
+    }
+
+    func testFetchOrdersReturnsLatest() async throws {
+        let plan = EsimPlan(id: "plan1", name: "Plan", network: "Mock", priceTHB: 120, speed: "Fast", validityDays: 5)
+        _ = try await service.createOrder(for: plan, provider: provider)
+        let orders = try service.fetchOrders()
+        XCTAssertEqual(orders.count, 1)
+        XCTAssertEqual(orders.first?.planId, "plan1")
+    }
+}

--- a/JourneyTH/Tests/PoiViewModelTests.swift
+++ b/JourneyTH/Tests/PoiViewModelTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import JourneyTH
+
+final class PoiViewModelTests: XCTestCase {
+    @MainActor
+    private func makeViewModel() -> (PoiViewModel, ItineraryRepository) {
+        let persistence = PersistenceController(inMemory: true)
+        let repository = ItineraryRepository(context: persistence.container.viewContext)
+        let viewModel = PoiViewModel(service: MockPoiService(loader: LocalDataLoader()), itineraryRepository: repository)
+        return (viewModel, repository)
+    }
+
+    @MainActor
+    func testLoadPoisUpdatesCollection() async throws {
+        let (viewModel, _) = makeViewModel()
+        await viewModel.load()
+        XCTAssertGreaterThanOrEqual(viewModel.pois.count, 10)
+        XCTAssertFalse(viewModel.filteredPois.isEmpty)
+    }
+
+    @MainActor
+    func testAddToItineraryPersistsItem() async throws {
+        let (viewModel, repository) = makeViewModel()
+        await viewModel.load()
+        guard let poi = viewModel.pois.first else {
+            XCTFail("Missing poi")
+            return
+        }
+        viewModel.addToItinerary(poi: poi)
+        let items = try repository.items()
+        XCTAssertEqual(items.count, 1)
+    }
+
+    func testLanguageTogglePersists() {
+        let defaults = UserDefaults.standard
+        defaults.set("en", forKey: "selectedLanguage")
+        defer { defaults.set("en", forKey: "selectedLanguage") }
+        let settings = AppSettings()
+        XCTAssertFalse(settings.useThai)
+        settings.useThai = true
+        let stored = defaults.string(forKey: "selectedLanguage")
+        XCTAssertEqual(stored, "th")
+    }
+}

--- a/JourneyTH/Tests/TransportViewModelTests.swift
+++ b/JourneyTH/Tests/TransportViewModelTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import JourneyTH
+
+final class TransportViewModelTests: XCTestCase {
+    func testRoutesDecodeFromJSON() throws {
+        let loader = LocalDataLoader()
+        let routes: [TransportRoute] = try loader.load("transport", as: [TransportRoute].self)
+        XCTAssertGreaterThanOrEqual(routes.count, 6)
+        XCTAssertEqual(routes.first?.steps.first?.mode, "Train")
+    }
+
+    func testSearchReturnsFilteredResults() async throws {
+        let service = MockTransportService(loader: LocalDataLoader())
+        let viewModel = await MainActor.run { TransportViewModel(service: service) }
+        await MainActor.run {
+            viewModel.origin = "Bangkok"
+            viewModel.destination = "Siam"
+            viewModel.search()
+        }
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let results = await MainActor.run { viewModel.routes }
+        XCTAssertTrue(results.contains { $0.destination.contains("Siam") })
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# JourneyTH-app
+# JourneyTH
+
+JourneyTH is a SwiftUI iOS 17+ application that showcases a travel assistant for Thailand. The app is designed around MVVM, Core Data persistence, and local-first mocks so it can run entirely offline. All services expose protocols with mock implementations, Apple Maps routes rely on MapKit, and UI strings are localized in Thai and English.
+
+## Features
+- **Transport** – Search BTS, bus, ferry, and walking combinations using mock routes from `transport.json`, pick a departure time, and open annotated MapKit polylines for any route.
+- **Discover** – Browse and filter 12+ points of interest by region and tags, switch between list and map modes, and add destinations to the itinerary.
+- **Itinerary** – Persist selected POIs with Core Data, reorder via drag & drop, calculate total minutes, and export a share sheet summary.
+- **eSIM & Payments** – Explore mock plans, generate QR previews, create offline orders, and mark activations that update order status badges.
+- **Account** – Toggle the live language between Thai/English, clear persisted data, and view local profile info.
+
+## Architecture & Tech Highlights
+- Swift 5.9+, SwiftUI-only UI components, NavigationStack, TabView, and modern MapKit APIs.
+- MVVM for each feature module with dedicated view models and services.
+- Core Data entities (`Itinerary`, `ItineraryItem`, `Order`) with repositories that expose async/await helpers.
+- Local JSON loaders (`transport.json`, `pois.json`, `esim_plans.json`) consumed via strongly typed models.
+- Mock service layer (`TransportServiceProtocol`, `PoiServiceProtocol`, `OrderServicing`, `PaymentProviding`, `PlanLoading`).
+- Localization via `Localizable.strings` (TH + EN) with runtime switching through `AppSettings` and `@AppStorage`.
+- Accessibility considerations: Dynamic Type-friendly layouts, descriptive VoiceOver labels, and haptic feedback on key actions.
+
+## Project Structure
+```
+JourneyTH-app/
+├─ JourneyTH.xcodeproj/
+├─ JourneyTH/
+│  ├─ JourneyTHApp.swift
+│  ├─ Features/
+│  │  ├─ Transport/…
+│  │  ├─ Discover/…
+│  │  ├─ Itinerary/…
+│  │  ├─ Esim/…
+│  │  ├─ Payments/…
+│  │  ├─ Account/…
+│  │  └─ Shared/…
+│  ├─ Services/
+│  ├─ Models/
+│  ├─ Resources/
+│  │  ├─ Data/
+│  │  ├─ Localizations/
+│  │  └─ Assets.xcassets/
+│  ├─ CoreData/
+│  └─ Tests/
+├─ generate_pbx.py
+└─ README.md
+```
+Use `python generate_pbx.py` to regenerate `JourneyTH.xcodeproj/project.pbxproj` after adding/removing files.
+
+## Building & Running
+1. Open `JourneyTH.xcodeproj` in Xcode 15 or newer.
+2. Select the **JourneyTH** scheme and an iPhone 15 Pro (iOS 17+) simulator or device.
+3. Build & Run. No external APIs are required; all data loads from bundled mocks.
+
+## Running Tests
+Execute the unit test suite (11 tests) from Xcode or via the command line on macOS:
+```sh
+xcodebuild test -scheme JourneyTH \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro'
+```
+
+## Local Data
+Sample data lives in `JourneyTH/Resources/Data/`:
+- `transport.json` – 6+ transport routes with multi-modal steps and sample coordinates.
+- `pois.json` – 12 points of interest with metadata, tags, and asset references.
+- `esim_plans.json` – Mock eSIM plans used by the checkout flow.
+
+## Localization & Accessibility
+All visible strings exist in both `en.lproj` and `th.lproj`. The Account tab exposes a toggle that updates `AppSettings` and rebinds the app’s locale. Components include VoiceOver labels, proper contrast, and respect Dynamic Type.
+
+## Known Limitations
+- Mock data only; no live network or payment integrations.
+- Map polylines and travel times are illustrative.
+- Assets are placeholder PNGs for demonstration.
+
+Happy travels! ✈️🌏

--- a/generate_pbx.py
+++ b/generate_pbx.py
@@ -1,0 +1,393 @@
+build_files = [
+    ("0B401BE29AC547BE97B2BBC9B6627BB6", "transport.json in Resources", "DF962B16DC574B18864520BB6C8F7B71", "transport.json"),
+    ("0F94DB5B0FFD414B94AD397F66E56566", "SharedComponents.swift in Sources", "C9BE5809471D4ACAA1CA31ABC1A828CF", "SharedComponents.swift"),
+    ("1929634F6BC04705965471981ED5791D", "PaymentsFeature.swift in Sources", "5E07DDF5C5684C05B2C6180FD987004E", "PaymentsFeature.swift"),
+    ("1B6300A431CB49C9B9C9AE33DFCDB2AA", "esim_plans.json in Resources", "91072CA6FE4546D1B11A026EA69CFD82", "esim_plans.json"),
+    ("2440393F08554AB9A76B5F8E2510A5BA", "PoiService.swift in Sources", "36EF10CCC0CE4398B9EB7064F895E64A", "PoiService.swift"),
+    ("45D007163FE0497FAB2C8BA754485F1C", "DiscoverFeature.swift in Sources", "C726873733654A5AAAF6C20DC82E409C", "DiscoverFeature.swift"),
+    ("4B108C3A7DAF479093E851E79F1FA206", "JourneyTHApp.swift in Sources", "B1FAABA271344FB88FE4C5787F826043", "JourneyTHApp.swift"),
+    ("5801E565694C43B4AEBD4E24883BDE5C", "Assets.xcassets in Resources", "9BDE6A65E50B42DAA7F0FCACE4E92175", "Assets.xcassets"),
+    ("6EE7497C8BA94366BF71BADBAAB3B6D5", "EsimPlan.swift in Sources", "F458FA79BA7C4F54BE5D37BA6F10D472", "EsimPlan.swift"),
+    ("7488EBB0C5D04819A202E98D74273823", "TransportService.swift in Sources", "6CD204A9303E4AEA898B8870E6A3EA6A", "TransportService.swift"),
+    ("7A7795B785544A33BD9E6A684293CD1C", "TransportRoute.swift in Sources", "F5A56803A65249C3A5630D2CC1411923", "TransportRoute.swift"),
+    ("8F7AD27BF2F4478791EAD2E08A94FB06", "ItineraryFeature.swift in Sources", "A56820073EF24CBD8E17952FC55E21CF", "ItineraryFeature.swift"),
+    ("9B334F16F8394AE1A85A13EB87239E3D", "EsimFeature.swift in Sources", "E606100D0DF34F5294D288409D91ED2A", "EsimFeature.swift"),
+    ("9DF485B541FB495BA3AB03F3FA70DAFE", "pois.json in Resources", "91C05ECBF1644A69BB0977C6EC8BB656", "pois.json"),
+    ("AA8829520D574593B2BE06F9A2D5252F", "Persistence.swift in Sources", "9A986428DD23477AAC6355BDD9A2D5C9", "Persistence.swift"),
+    ("B3E3EF69B8714C8EB3E12813A98B3C34", "OrderModel.swift in Sources", "5D77BEDAEFF74199B55147D585E814C2", "OrderModel.swift"),
+    ("BA964D783A6C4FC49CB22A946A016EB8", "AccountFeature.swift in Sources", "BD8927F09F3C46BFA3E1AB54A2573C45", "AccountFeature.swift"),
+    ("CA08AEE838414AAD8190629D7522D4D4", "PlanLoader.swift in Sources", "FC46CE28CE744A56B56D012F8855A4DA", "PlanLoader.swift"),
+    ("D079E00F5BFF442E8B3E058370F57DBD", "OrderService.swift in Sources", "16245B883427418D8E6EB5E715C2608D", "OrderService.swift"),
+    ("E12A73A08ECD47DF8681D9109908DC95", "LocalDataLoader.swift in Sources", "F5E25C83484E4C5D85F2759A83C8B002", "LocalDataLoader.swift"),
+    ("EF419844F2084FC0904F53003C96382B", "AppSettings.swift in Sources", "05C0BD92CD2642EFB42B64D0B096EDEE", "AppSettings.swift"),
+    ("F870F5C828DA4AE3A8AB3B43507FA391", "TransportFeature.swift in Sources", "76BAEE7AA8CD42888B6B8297F411B8A2", "TransportFeature.swift"),
+    ("FF192049B2AC4E7BB21949AF6945662E", "JourneyTH.xcdatamodeld in Resources", "6ADEDD1F99744762AAA2BC49BD418770", "JourneyTH.xcdatamodeld"),
+    ("A94D8F43BA194F0D94B5602F00D5F01E", "Localizable.strings in Resources", "814928D0D8DD4EE3B92B8702FFA15231", "Localizable.strings"),
+]
+
+test_build_files = [
+    ("A623F952FAFE4F3CB6B23909FC329D80", "TransportViewModelTests.swift in Sources", "AD9639B5FA9442EF8C93471C274351F2", "TransportViewModelTests.swift"),
+    ("6408A3AF5B424F7B8302A613E58108AF", "PoiViewModelTests.swift in Sources", "AFF06062C05041329C88A5C549D9C188", "PoiViewModelTests.swift"),
+    ("3ABCFA3A7D0D4E4EAE2866772E2F8201", "ItineraryRepositoryTests.swift in Sources", "F66E467385C24E37AC1397AF80F041C9", "ItineraryRepositoryTests.swift"),
+    ("05833FE86B234D20AAE4651C70D84BE2", "OrderServiceTests.swift in Sources", "52A4D820998E4546898C8695748D6604", "OrderServiceTests.swift"),
+]
+
+resource_build_files = [
+    "0B401BE29AC547BE97B2BBC9B6627BB6",
+    "1B6300A431CB49C9B9C9AE33DFCDB2AA",
+    "9DF485B541FB495BA3AB03F3FA70DAFE",
+    "5801E565694C43B4AEBD4E24883BDE5C",
+    "FF192049B2AC4E7BB21949AF6945662E",
+    "A94D8F43BA194F0D94B5602F00D5F01E",
+]
+
+app_sources = [
+    "4B108C3A7DAF479093E851E79F1FA206",
+    "0F94DB5B0FFD414B94AD397F66E56566",
+    "1929634F6BC04705965471981ED5791D",
+    "2440393F08554AB9A76B5F8E2510A5BA",
+    "45D007163FE0497FAB2C8BA754485F1C",
+    "6EE7497C8BA94366BF71BADBAAB3B6D5",
+    "7488EBB0C5D04819A202E98D74273823",
+    "7A7795B785544A33BD9E6A684293CD1C",
+    "8F7AD27BF2F4478791EAD2E08A94FB06",
+    "9B334F16F8394AE1A85A13EB87239E3D",
+    "AA8829520D574593B2BE06F9A2D5252F",
+    "B3E3EF69B8714C8EB3E12813A98B3C34",
+    "BA964D783A6C4FC49CB22A946A016EB8",
+    "CA08AEE838414AAD8190629D7522D4D4",
+    "D079E00F5BFF442E8B3E058370F57DBD",
+    "E12A73A08ECD47DF8681D9109908DC95",
+    "EF419844F2084FC0904F53003C96382B",
+    "F870F5C828DA4AE3A8AB3B43507FA391",
+]
+
+app_resources_phase = "9B844106FEE54C71BEEC7E23B667677E"
+app_sources_phase = "FCDB113566C3466AA3087BBD7DD45D58"
+app_frameworks_phase = "1826E90C4AC3439983EB4553E23F8ED2"
+
+test_sources_phase = "0BA224D65BD8452A922D1A28C536C5DF"
+test_resources_phase = "4B95F9C09D234038868F3462F44F64AB"
+test_frameworks_phase = "C68CE1376718499FB02CD49079B41642"
+
+build_file_map = {
+    bid: (comment, file_ref, file_comment)
+    for bid, comment, file_ref, file_comment in build_files + test_build_files
+}
+
+project_debug_settings = [
+    ("ALWAYS_SEARCH_USER_PATHS", "NO"),
+    ("CLANG_WARN_DOCUMENTATION_COMMENTS", "YES"),
+    ("CLANG_WARN_UNGUARDED_AVAILABILITY", "YES_AGGRESSIVE"),
+    ("DEBUG_INFORMATION_FORMAT", "dwarf"),
+    ("ENABLE_TESTABILITY", "YES"),
+    ("GCC_C_LANGUAGE_STANDARD", "gnu17"),
+    ("GCC_NO_COMMON_BLOCKS", "YES"),
+    ("GCC_WARN_ABOUT_RETURN_TYPE", "YES_ERROR"),
+    ("GCC_WARN_UNDECLARED_SELECTOR", "YES"),
+    ("GCC_WARN_UNUSED_FUNCTION", "YES"),
+    ("GCC_WARN_UNUSED_VARIABLE", "YES"),
+    ("IPHONEOS_DEPLOYMENT_TARGET", "17.0"),
+    ("MTL_ENABLE_DEBUG_INFO", "INCLUDE_SOURCE"),
+    ("ONLY_ACTIVE_ARCH", "YES"),
+    ("SWIFT_ACTIVE_COMPILATION_CONDITIONS", "DEBUG"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "\"-Onone\""),
+    ("SWIFT_VERSION", "5.0"),
+]
+
+project_release_settings = [
+    ("ALWAYS_SEARCH_USER_PATHS", "NO"),
+    ("CLANG_WARN_DOCUMENTATION_COMMENTS", "YES"),
+    ("CLANG_WARN_UNGUARDED_AVAILABILITY", "YES_AGGRESSIVE"),
+    ("GCC_C_LANGUAGE_STANDARD", "gnu17"),
+    ("GCC_NO_COMMON_BLOCKS", "YES"),
+    ("GCC_WARN_ABOUT_RETURN_TYPE", "YES_ERROR"),
+    ("GCC_WARN_UNDECLARED_SELECTOR", "YES"),
+    ("GCC_WARN_UNUSED_FUNCTION", "YES"),
+    ("GCC_WARN_UNUSED_VARIABLE", "YES"),
+    ("IPHONEOS_DEPLOYMENT_TARGET", "17.0"),
+    ("MTL_ENABLE_DEBUG_INFO", "NO"),
+    ("SWIFT_COMPILATION_MODE", "wholemodule"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "\"-O\""),
+    ("SWIFT_VERSION", "5.0"),
+    ("VALIDATE_PRODUCT", "YES"),
+]
+
+app_debug_settings = [
+    ("ASSETCATALOG_COMPILER_APPICON_NAME", "AppIcon"),
+    ("CODE_SIGN_STYLE", "Automatic"),
+    ("CURRENT_PROJECT_VERSION", "1"),
+    ("GENERATE_INFOPLIST_FILE", "YES"),
+    ("INFOPLIST_KEY_UIApplicationSceneManifest_Generation", "YES"),
+    ("INFOPLIST_KEY_UILaunchScreen_Generation", "YES"),
+    ("IPHONEOS_DEPLOYMENT_TARGET", "17.0"),
+    ("MARKETING_VERSION", "1.0"),
+    ("PRODUCT_BUNDLE_IDENTIFIER", "com.example.JourneyTH"),
+    ("PRODUCT_NAME", "\"$(TARGET_NAME)\""),
+    ("SWIFT_EMIT_LOC_STRINGS", "YES"),
+    ("SWIFT_VERSION", "5.0"),
+    ("TARGETED_DEVICE_FAMILY", "1"),
+]
+
+app_release_settings = [
+    ("ASSETCATALOG_COMPILER_APPICON_NAME", "AppIcon"),
+    ("CODE_SIGN_STYLE", "Automatic"),
+    ("CURRENT_PROJECT_VERSION", "1"),
+    ("GENERATE_INFOPLIST_FILE", "YES"),
+    ("INFOPLIST_KEY_UIApplicationSceneManifest_Generation", "YES"),
+    ("INFOPLIST_KEY_UILaunchScreen_Generation", "YES"),
+    ("IPHONEOS_DEPLOYMENT_TARGET", "17.0"),
+    ("MARKETING_VERSION", "1.0"),
+    ("PRODUCT_BUNDLE_IDENTIFIER", "com.example.JourneyTH"),
+    ("PRODUCT_NAME", "\"$(TARGET_NAME)\""),
+    ("SWIFT_EMIT_LOC_STRINGS", "YES"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "\"-Owholemodule\""),
+    ("SWIFT_VERSION", "5.0"),
+    ("TARGETED_DEVICE_FAMILY", "1"),
+]
+
+test_debug_settings = [
+    ("CODE_SIGN_STYLE", "Automatic"),
+    ("GENERATE_INFOPLIST_FILE", "YES"),
+    ("IPHONEOS_DEPLOYMENT_TARGET", "17.0"),
+    ("PRODUCT_BUNDLE_IDENTIFIER", "com.example.JourneyTHTests"),
+    ("PRODUCT_NAME", "\"$(TARGET_NAME)\""),
+    ("SWIFT_VERSION", "5.0"),
+    ("TARGETED_DEVICE_FAMILY", "1"),
+]
+
+test_release_settings = list(test_debug_settings)
+
+
+def append_build_configuration(lines, identifier, name, settings):
+    lines.append(f"\t{identifier} /* {name} */ = {{")
+    lines.append("\t\tisa = XCBuildConfiguration;")
+    lines.append("\t\tbuildSettings = {")
+    for key, value in settings:
+        lines.append(f"\t\t\t{key} = {value};")
+    lines.append("\t\t};")
+    lines.append(f"\t\tname = {name};")
+    lines.append("\t};")
+
+file_refs = {
+    "B1FAABA271344FB88FE4C5787F826043": ("JourneyTHApp.swift", "sourcecode.swift", "JourneyTHApp.swift", "<group>", None),
+    "05C0BD92CD2642EFB42B64D0B096EDEE": ("AppSettings.swift", "sourcecode.swift", "AppSettings.swift", "<group>", None),
+    "C9BE5809471D4ACAA1CA31ABC1A828CF": ("SharedComponents.swift", "sourcecode.swift", "SharedComponents.swift", "<group>", None),
+    "76BAEE7AA8CD42888B6B8297F411B8A2": ("TransportFeature.swift", "sourcecode.swift", "TransportFeature.swift", "<group>", None),
+    "C726873733654A5AAAF6C20DC82E409C": ("DiscoverFeature.swift", "sourcecode.swift", "DiscoverFeature.swift", "<group>", None),
+    "A56820073EF24CBD8E17952FC55E21CF": ("ItineraryFeature.swift", "sourcecode.swift", "ItineraryFeature.swift", "<group>", None),
+    "E606100D0DF34F5294D288409D91ED2A": ("EsimFeature.swift", "sourcecode.swift", "EsimFeature.swift", "<group>", None),
+    "5E07DDF5C5684C05B2C6180FD987004E": ("PaymentsFeature.swift", "sourcecode.swift", "PaymentsFeature.swift", "<group>", None),
+    "BD8927F09F3C46BFA3E1AB54A2573C45": ("AccountFeature.swift", "sourcecode.swift", "AccountFeature.swift", "<group>", None),
+    "F5A56803A65249C3A5630D2CC1411923": ("TransportRoute.swift", "sourcecode.swift", "TransportRoute.swift", "<group>", None),
+    "491BAA9C25A8486C8B4A912173BDFF9C": ("Poi.swift", "sourcecode.swift", "Poi.swift", "<group>", None),
+    "F458FA79BA7C4F54BE5D37BA6F10D472": ("EsimPlan.swift", "sourcecode.swift", "EsimPlan.swift", "<group>", None),
+    "5D77BEDAEFF74199B55147D585E814C2": ("OrderModel.swift", "sourcecode.swift", "OrderModel.swift", "<group>", None),
+    "F5E25C83484E4C5D85F2759A83C8B002": ("LocalDataLoader.swift", "sourcecode.swift", "LocalDataLoader.swift", "<group>", None),
+    "6CD204A9303E4AEA898B8870E6A3EA6A": ("TransportService.swift", "sourcecode.swift", "TransportService.swift", "<group>", None),
+    "36EF10CCC0CE4398B9EB7064F895E64A": ("PoiService.swift", "sourcecode.swift", "PoiService.swift", "<group>", None),
+    "16245B883427418D8E6EB5E715C2608D": ("OrderService.swift", "sourcecode.swift", "OrderService.swift", "<group>", None),
+    "9A986428DD23477AAC6355BDD9A2D5C9": ("Persistence.swift", "sourcecode.swift", "Persistence.swift", "<group>", None),
+    "FC46CE28CE744A56B56D012F8855A4DA": ("PlanLoader.swift", "sourcecode.swift", "PlanLoader.swift", "<group>", None),
+    "DF962B16DC574B18864520BB6C8F7B71": ("transport.json", "text.json", "transport.json", "<group>", None),
+    "91C05ECBF1644A69BB0977C6EC8BB656": ("pois.json", "text.json", "pois.json", "<group>", None),
+    "91072CA6FE4546D1B11A026EA69CFD82": ("esim_plans.json", "text.json", "esim_plans.json", "<group>", None),
+    "9BDE6A65E50B42DAA7F0FCACE4E92175": ("Assets.xcassets", "folder.assetcatalog", "Assets.xcassets", "<group>", None),
+    "6ADEDD1F99744762AAA2BC49BD418770": ("JourneyTH.xcdatamodeld", "wrapper.xcdatamodeld", "JourneyTH.xcdatamodeld", "<group>", None),
+    "AD9639B5FA9442EF8C93471C274351F2": ("TransportViewModelTests.swift", "sourcecode.swift", "TransportViewModelTests.swift", "<group>", None),
+    "AFF06062C05041329C88A5C549D9C188": ("PoiViewModelTests.swift", "sourcecode.swift", "PoiViewModelTests.swift", "<group>", None),
+    "F66E467385C24E37AC1397AF80F041C9": ("ItineraryRepositoryTests.swift", "sourcecode.swift", "ItineraryRepositoryTests.swift", "<group>", None),
+    "52A4D820998E4546898C8695748D6604": ("OrderServiceTests.swift", "sourcecode.swift", "OrderServiceTests.swift", "<group>", None),
+    "2C5C847824774C5C86885E19AD6D7FAB": ("en", "text.plist.strings", "en.lproj/Localizable.strings", "<group>", "en"),
+    "B44213AB2E084C7DA4A40A73796DD149": ("th", "text.plist.strings", "th.lproj/Localizable.strings", "<group>", "th"),
+    "EDEFAF81E471449BA01CDB83D7DE73CF": ("JourneyTH.app", "wrapper.application", "JourneyTH.app", "BUILT_PRODUCTS_DIR", None),
+    "C460CDD0F8484BC9B1898F4E32831B7B": ("JourneyTHTests.xctest", "wrapper.cfbundle", "JourneyTHTests.xctest", "BUILT_PRODUCTS_DIR", None),
+}
+
+variant_group = ("814928D0D8DD4EE3B92B8702FFA15231", "Localizable.strings", ["2C5C847824774C5C86885E19AD6D7FAB", "B44213AB2E084C7DA4A40A73796DD149"])
+
+# PBXGroup definitions
+groups = {
+    "C82283E8BE864528A747D2F7A83317C0": ("", None, ["0DB5D6543BA0449EB3D7BCAEA31D226B", "15705C559F48472EAD723162B86AC98F", "462D4819A0CB4833AE150112EF7A29AB", "49EE75DF10BF469FB5DB19617997EA50"]),
+    "0DB5D6543BA0449EB3D7BCAEA31D226B": ("JourneyTH", "JourneyTH", ["B1FAABA271344FB88FE4C5787F826043", "992568F9E3514B579BFB32E8DC41C67B", "64E0E4D8BF444CE7B22882C10CCBCC8E", "4B25A2265D8A459BAA10F887997A1334", "F733CF0E84FC4FCA86536ADB9C26B44D", "47E0D37270D244A89682C822C4E78EF9"]),
+    "992568F9E3514B579BFB32E8DC41C67B": ("Features", "Features", ["37354241611F45799E3D32649E675F99", "86D459A535584AEA9C453098A55F57AB", "D4400F01B8A84115B9250B4CEEE7D245", "C4F26EBE073C4274BB587AF2E33B10FD", "69D8BC34DE8E4CBDBD532E2AE86D0597", "3DD0AAD2ED104C8081D3774D9D1F9C22", "DC925BCF35A948FCA68A9EFA95DF95AC"]),
+    "37354241611F45799E3D32649E675F99": ("Shared", "Shared", ["05C0BD92CD2642EFB42B64D0B096EDEE", "C9BE5809471D4ACAA1CA31ABC1A828CF"]),
+    "86D459A535584AEA9C453098A55F57AB": ("Transport", "Transport", ["76BAEE7AA8CD42888B6B8297F411B8A2"]),
+    "D4400F01B8A84115B9250B4CEEE7D245": ("Discover", "Discover", ["C726873733654A5AAAF6C20DC82E409C"]),
+    "C4F26EBE073C4274BB587AF2E33B10FD": ("Itinerary", "Itinerary", ["A56820073EF24CBD8E17952FC55E21CF"]),
+    "69D8BC34DE8E4CBDBD532E2AE86D0597": ("Esim", "Esim", ["E606100D0DF34F5294D288409D91ED2A"]),
+    "3DD0AAD2ED104C8081D3774D9D1F9C22": ("Payments", "Payments", ["5E07DDF5C5684C05B2C6180FD987004E"]),
+    "DC925BCF35A948FCA68A9EFA95DF95AC": ("Account", "Account", ["BD8927F09F3C46BFA3E1AB54A2573C45"]),
+    "64E0E4D8BF444CE7B22882C10CCBCC8E": ("Models", "Models", ["F5A56803A65249C3A5630D2CC1411923", "491BAA9C25A8486C8B4A912173BDFF9C", "F458FA79BA7C4F54BE5D37BA6F10D472", "5D77BEDAEFF74199B55147D585E814C2"]),
+    "4B25A2265D8A459BAA10F887997A1334": ("Services", "Services", ["F5E25C83484E4C5D85F2759A83C8B002", "6CD204A9303E4AEA898B8870E6A3EA6A", "36EF10CCC0CE4398B9EB7064F895E64A", "16245B883427418D8E6EB5E715C2608D", "9A986428DD23477AAC6355BDD9A2D5C9", "FC46CE28CE744A56B56D012F8855A4DA"]),
+    "F733CF0E84FC4FCA86536ADB9C26B44D": ("Resources", "Resources", ["AA1467DA18A6437DB8006AD167FD3E01", "3E73571D642847898629AB66C51C48A9", "9BDE6A65E50B42DAA7F0FCACE4E92175"]),
+    "AA1467DA18A6437DB8006AD167FD3E01": ("Data", "Data", ["DF962B16DC574B18864520BB6C8F7B71", "91C05ECBF1644A69BB0977C6EC8BB656", "91072CA6FE4546D1B11A026EA69CFD82"]),
+    "3E73571D642847898629AB66C51C48A9": ("Localizations", "Localizations", ["814928D0D8DD4EE3B92B8702FFA15231"]),
+    "47E0D37270D244A89682C822C4E78EF9": ("CoreData", "CoreData", ["6ADEDD1F99744762AAA2BC49BD418770"]),
+    "15705C559F48472EAD723162B86AC98F": ("Tests", "Tests", ["AD9639B5FA9442EF8C93471C274351F2", "AFF06062C05041329C88A5C549D9C188", "F66E467385C24E37AC1397AF80F041C9", "52A4D820998E4546898C8695748D6604"]),
+    "462D4819A0CB4833AE150112EF7A29AB": ("Products", None, ["EDEFAF81E471449BA01CDB83D7DE73CF", "C460CDD0F8484BC9B1898F4E32831B7B"]),
+    "49EE75DF10BF469FB5DB19617997EA50": ("Frameworks", None, []),
+}
+
+variant_group_id, variant_name, variant_children = variant_group
+
+app_target = "39B43CB0CC254B7EB0DC56A68B1B3DA8"
+test_target = "7D5E5DEE4D09405DA95019C510A45B34"
+project_id = "37088684A8C14E49AF159A3CB05ADBDB"
+
+app_product = "EDEFAF81E471449BA01CDB83D7DE73CF"
+test_product = "C460CDD0F8484BC9B1898F4E32831B7B"
+
+lines = []
+lines.append("// !$*UTF8*$!")
+lines.append("{")
+lines.append("\tarchiveVersion = 1;")
+lines.append("\tclasses = {\n\t};")
+lines.append("\tobjectVersion = 56;")
+lines.append("\tobjects = {")
+
+lines.append("\n/* Begin PBXBuildFile section */")
+for bid, comment, file_ref, file_comment in build_files + test_build_files:
+    lines.append(f"\t{bid} /* {comment} */ = {{isa = PBXBuildFile; fileRef = {file_ref} /* {file_comment} */; }};")
+lines.append("/* End PBXBuildFile section */")
+
+lines.append("\n/* Begin PBXContainerItemProxy section */")
+lines.append(f"\t0277F47312AB481FBD115BB4A9F61D96 /* PBXContainerItemProxy */ = {{isa = PBXContainerItemProxy; containerPortal = {project_id} /* Project object */; proxyType = 1; remoteGlobalIDString = {app_target}; remoteInfo = JourneyTH; }};")
+lines.append("/* End PBXContainerItemProxy section */")
+
+lines.append("\n/* Begin PBXFileReference section */")
+for fid, (comment, ftype, path, source_tree, name) in file_refs.items():
+    attrs = ["isa = PBXFileReference", f"lastKnownFileType = {ftype}"]
+    if name is not None:
+        attrs.append(f"name = {name}")
+    attrs.append(f"path = {path}")
+    attrs.append(f"sourceTree = {source_tree}")
+    lines.append(f"\t{fid} /* {comment} */ = {{{'; '.join(attrs)}; }};")
+lines.append("/* End PBXFileReference section */")
+
+lines.append("\n/* Begin PBXFrameworksBuildPhase section */")
+for phase in (app_frameworks_phase, test_frameworks_phase):
+    lines.append(f"\t{phase} /* Frameworks */ = {{")
+    lines.append("\t\tisa = PBXFrameworksBuildPhase;")
+    lines.append("\t\tbuildActionMask = 2147483647;")
+    lines.append("\t\tfiles = (")
+    lines.append("\t\t);")
+    lines.append("\t\trunOnlyForDeploymentPostprocessing = 0;")
+    lines.append("\t};")
+lines.append("/* End PBXFrameworksBuildPhase section */")
+
+lines.append("\n/* Begin PBXGroup section */")
+for gid, (name, path, children) in groups.items():
+    group_lines = ["\t" + gid + " = {isa = PBXGroup;"]
+    group_lines.append("\t\tchildren = (")
+    for child in children:
+        if child in file_refs:
+            comment = file_refs[child][0]
+        elif child == variant_group_id:
+            comment = variant_name
+        else:
+            comment = groups[child][0]
+        if not comment:
+            comment = child
+        group_lines.append(f"\t\t\t{child} /* {comment} */,")
+    group_lines.append("\t\t);")
+    if name:
+        group_lines.append(f"\t\tname = {name};")
+    if path:
+        group_lines.append(f"\t\tpath = {path};")
+    group_lines.append("\t\tsourceTree = <group>;")
+    group_lines.append("\t};")
+    lines.extend(group_lines)
+lines.append("/* End PBXGroup section */")
+
+lines.append("\n/* Begin PBXNativeTarget section */")
+lines.append(f"\t{app_target} /* JourneyTH */ = {{isa = PBXNativeTarget; buildConfigurationList = A94D40C2F8FC42629F640CD095B796A5 /* Build configuration list for PBXNativeTarget \"JourneyTH\" */; buildPhases = (\n\t\t{app_frameworks_phase} /* Frameworks */,\n\t\t{app_sources_phase} /* Sources */,\n\t\t{app_resources_phase} /* Resources */\n\t); buildRules = (\n\t); dependencies = (\n\t); name = JourneyTH; productName = JourneyTH; productReference = {app_product} /* JourneyTH.app */; productType = \"com.apple.product-type.application\"; }};")
+lines.append(f"\t{test_target} /* JourneyTHTests */ = {{isa = PBXNativeTarget; buildConfigurationList = BA4170AD04464A4E9E8BC6AA57094B2D /* Build configuration list for PBXNativeTarget \"JourneyTHTests\" */; buildPhases = (\n\t\t{test_frameworks_phase} /* Frameworks */,\n\t\t{test_sources_phase} /* Sources */,\n\t\t{test_resources_phase} /* Resources */\n\t); buildRules = (\n\t); dependencies = (\n\t4359A57CB6D84B00A3060827FA3B678F /* PBXTargetDependency */\n\t); name = JourneyTHTests; productName = JourneyTHTests; productReference = {test_product} /* JourneyTHTests.xctest */; productType = \"com.apple.product-type.bundle.unit-test\"; }};")
+lines.append("/* End PBXNativeTarget section */")
+
+lines.append("\n/* Begin PBXProject section */")
+lines.append(f"\t{project_id} /* Project object */ = {{isa = PBXProject; attributes = {{BuildIndependentTargetsInParallel = YES; LastSwiftUpdateCheck = 1500; LastUpgradeCheck = 1500; TargetAttributes = {{{app_target} = {{CreatedOnToolsVersion = 15.0;}}; {test_target} = {{CreatedOnToolsVersion = 15.0; TestTargetID = {app_target};}};}};}}; buildConfigurationList = 48FE4AC96B74498194B0D75F4A2105CF /* Build configuration list for PBXProject \"JourneyTH\" */; compatibilityVersion = \"Xcode 15.0\"; developmentRegion = en; hasScannedForEncodings = 0; knownRegions = (\n\ten,\n\tBase,\n\tth\n\t); mainGroup = C82283E8BE864528A747D2F7A83317C0; productRefGroup = 462D4819A0CB4833AE150112EF7A29AB; projectDirPath = \"\"; projectRoot = \"\"; targets = (\n\t{app_target} /* JourneyTH */,\n\t{test_target} /* JourneyTHTests */\n\t); }};")
+lines.append("/* End PBXProject section */")
+
+lines.append("\n/* Begin PBXResourcesBuildPhase section */")
+lines.append(f"\t{app_resources_phase} /* Resources */ = {{")
+lines.append("\t\tisa = PBXResourcesBuildPhase;")
+lines.append("\t\tbuildActionMask = 2147483647;")
+lines.append("\t\tfiles = (")
+for fid in resource_build_files:
+    comment, _, _ = build_file_map[fid]
+    lines.append(f"\t\t\t{fid} /* {comment} */,")
+lines.append("\t\t);")
+lines.append("\t\trunOnlyForDeploymentPostprocessing = 0;")
+lines.append("\t};")
+lines.append(f"\t{test_resources_phase} /* Resources */ = {{")
+lines.append("\t\tisa = PBXResourcesBuildPhase;")
+lines.append("\t\tbuildActionMask = 2147483647;")
+lines.append("\t\tfiles = (")
+lines.append("\t\t);")
+lines.append("\t\trunOnlyForDeploymentPostprocessing = 0;")
+lines.append("\t};")
+lines.append("/* End PBXResourcesBuildPhase section */")
+
+lines.append("\n/* Begin PBXSourcesBuildPhase section */")
+lines.append(f"\t{app_sources_phase} /* Sources */ = {{")
+lines.append("\t\tisa = PBXSourcesBuildPhase;")
+lines.append("\t\tbuildActionMask = 2147483647;")
+lines.append("\t\tfiles = (")
+for fid in app_sources:
+    comment, _, _ = build_file_map[fid]
+    lines.append(f"\t\t\t{fid} /* {comment} */,")
+lines.append("\t\t);")
+lines.append("\t\trunOnlyForDeploymentPostprocessing = 0;")
+lines.append("\t};")
+lines.append(f"\t{test_sources_phase} /* Sources */ = {{")
+lines.append("\t\tisa = PBXSourcesBuildPhase;")
+lines.append("\t\tbuildActionMask = 2147483647;")
+lines.append("\t\tfiles = (")
+for fid, _, _, _ in test_build_files:
+    comment, _, _ = build_file_map[fid]
+    lines.append(f"\t\t\t{fid} /* {comment} */,")
+lines.append("\t\t);")
+lines.append("\t\trunOnlyForDeploymentPostprocessing = 0;")
+lines.append("\t};")
+lines.append("/* End PBXSourcesBuildPhase section */")
+
+lines.append("\n/* Begin PBXTargetDependency section */")
+lines.append(f"\t4359A57CB6D84B00A3060827FA3B678F /* PBXTargetDependency */ = {{isa = PBXTargetDependency; target = {app_target} /* JourneyTH */; targetProxy = 0277F47312AB481FBD115BB4A9F61D96 /* PBXContainerItemProxy */; }};")
+lines.append("/* End PBXTargetDependency section */")
+
+lines.append("\n/* Begin PBXVariantGroup section */")
+lines.append(f"\t{variant_group_id} /* {variant_name} */ = {{")
+lines.append("\t\tisa = PBXVariantGroup;")
+lines.append("\t\tchildren = (")
+for child in variant_children:
+    child_comment = file_refs[child][0]
+    lines.append(f"\t\t\t{child} /* {child_comment} */,")
+lines.append("\t\t);")
+lines.append(f"\t\tname = {variant_name};")
+lines.append("\t\tsourceTree = <group>;")
+lines.append("\t};")
+lines.append("/* End PBXVariantGroup section */")
+
+# Build configurations
+lines.append("\n/* Begin XCBuildConfiguration section */")
+append_build_configuration(lines, "745C0DB40D0B43FC9FEE81AF97CC6BBC", "Debug", project_debug_settings)
+append_build_configuration(lines, "3ADF79AEEBEA4A0ABD6660461B4FFA29", "Release", project_release_settings)
+append_build_configuration(lines, "BD36F355AE5D404DB99FE11F5B38BE68", "Debug", app_debug_settings)
+append_build_configuration(lines, "2A02174B22884437BA2130EFCF1DAA63", "Release", app_release_settings)
+append_build_configuration(lines, "0B53C482991D4CB3A5D001140109523E", "Debug", test_debug_settings)
+append_build_configuration(lines, "77E183D9A2774B0D8B985CED6707BC7F", "Release", test_release_settings)
+lines.append("/* End XCBuildConfiguration section */")
+
+lines.append("\n/* Begin XCConfigurationList section */")
+lines.append("\t48FE4AC96B74498194B0D75F4A2105CF /* Build configuration list for PBXProject \"JourneyTH\" */ = {isa = XCConfigurationList; buildConfigurations = (745C0DB40D0B43FC9FEE81AF97CC6BBC /* Debug */, 3ADF79AEEBEA4A0ABD6660461B4FFA29 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };")
+lines.append("\tA94D40C2F8FC42629F640CD095B796A5 /* Build configuration list for PBXNativeTarget \"JourneyTH\" */ = {isa = XCConfigurationList; buildConfigurations = (BD36F355AE5D404DB99FE11F5B38BE68 /* Debug */, 2A02174B22884437BA2130EFCF1DAA63 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };")
+lines.append("\tBA4170AD04464A4E9E8BC6AA57094B2D /* Build configuration list for PBXNativeTarget \"JourneyTHTests\" */ = {isa = XCConfigurationList; buildConfigurations = (0B53C482991D4CB3A5D001140109523E /* Debug */, 77E183D9A2774B0D8B985CED6707BC7F /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };")
+lines.append("/* End XCConfigurationList section */")
+
+lines.append("\t};")
+lines.append(f"\trootObject = {project_id} /* Project object */;")
+lines.append("}")
+
+with open("JourneyTH.xcodeproj/project.pbxproj", "w") as f:
+    f.write("\n".join(lines))


### PR DESCRIPTION
## Summary
- replace the tab bar icons and POI image displays with SF Symbol driven views so no PNG resources are needed
- add reusable POI symbol badge/slide components backed by a gradient palette to keep Discover screens expressive without binary assets
- swap the app icon to an SVG asset and remove the bundled image sets that triggered the PR upload restriction

## Testing
- not run (requires macOS with Xcode)


------
https://chatgpt.com/codex/tasks/task_e_68d36422da108329ac58e67b5e7aa064